### PR TITLE
PS script uses .NET 4 features, so requires Powershell 3.0

### DIFF
--- a/semver-buildnumber/MRPP_SemVer_BuildNumber.xml
+++ b/semver-buildnumber/MRPP_SemVer_BuildNumber.xml
@@ -18,6 +18,7 @@
           <param name="jetbrains_powershell_errorToError" value="error" />
           <param name="jetbrains_powershell_script_mode" value="CODE" />
           <param name="jetbrains_powershell_bitness" value="x86" />
+          <param name="jetbrains_powershell_minVersion" value="3.0" />
           <param name="teamcity.step.mode" value="default" />
           <param name="jetbrains_powershell_script_code">
             <![CDATA[


### PR DESCRIPTION
The Powershell script code uses String.IsNullOrWhiteSpace. This method was introduced in .NET 4.0. PowerShell 3.0 is required to use .NET 4.0 features.
