### PR TITLE
PHPUnit Runner failed fix while coverage is disabled

### DIFF
--- a/php/MRPP_PHP_PHPUnit.xml
+++ b/php/MRPP_PHP_PHPUnit.xml
@@ -37,6 +37,9 @@
 <condition property="phpunit.coverage.param" value="--coverage-html ${phpunit.coverage.dir}">
   <istrue value="${phpunit.coverage.set}"/>
 </condition>
+<condition property="phpunit.coverage.param" value="">
+  <isfalse value="${phpunit.coverage.set}"/>
+</condition>
 
 <target name="runTests" depends="getPhpUnit,runPhpUnitPhar,runPhpUnitRuntime">
 </target>


### PR DESCRIPTION
phpunit.coverage.param is missing when phpunit.coverage.set is set to false.
