### PR TITLE
Corrected MetaRunner due to changes in GitVersion

### DIFF
--- a/gitversion/MR_GitVersion.xml
+++ b/gitversion/MR_GitVersion.xml
@@ -74,6 +74,7 @@ function Append-IfSpecified($appendTo, $command, $value) {
 function Build-Arguments() {
     $args = "";
     if (Test-IsSpecified $workingDir) {
+        $workingDir = $workingDir.TrimEnd('\')
         $args = """$workingDir"""
     }
     $args = Append-IfSpecified $args "url" $url
@@ -91,7 +92,7 @@ function Build-Arguments() {
         $args = Append-IfSpecified $args "projargs" $projargs
     }
     if ($updateAssemblyInfo -eq "true") {
-        $args = "$args /UpdateAssemblyInfo"
+        $args = "$args /UpdateAssemblyInfo true"
     }
     if ($output -eq "json" -and (Test-IsSpecified $outputFile)) {
         $args = "$args > ""$outputFile"""
@@ -143,7 +144,13 @@ try {
     $proj = Join-ToWorkingDirectoryIfSpecified $proj
 
     $arguments = Build-Arguments
-    $safeArgs = $arguments.Replace($password, "*****").Replace("'", """")
+    
+    $safeArgs = $arguments.Replace("'", """")
+    
+    if($password) {
+      $safeArgs = $arguments.Replace($password, "*****")
+    }
+    
     Write-Host "##teamcity[progressMessage 'Running: $gitversion $safeArgs']"
     iex "$gitversion $arguments"
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
@robdmoore can you review the following?  If you are ok with them, hopefully they can get merged in.

Found a couple issues...
- When a checkout directory is not specified, the workingDir variable has a trailing \ which causes an issue when passing arguments into the GitVersion.exe
- If no password is specified in TeamCity configuration, the .Replace fails, therefore we should only do it if there is a password provided
- A new modification to the UpdateAssemblyInfo overload means that you need to specify the additional parameter, otherwise GitVersion fails to parse the arguments correctly
