### PR TITLE
Added option to update GitVersion using Choco

### DIFF
--- a/gitversion/MR_GitVersion.xml
+++ b/gitversion/MR_GitVersion.xml
@@ -16,6 +16,7 @@
       <param name="mr.GitVersion.proj" value="" spec="text description='Optional MSBuild file relative to the working directory to run using GitVersion - environment vars will be available to the process.' display='normal' label='MSBuild File:'" />
       <param name="mr.GitVersion.projArgs" value="" spec="text description='If an MSBuild file is specified then arguments to pass to MSBuild.' display='normal' label='MSBuild Arguments:'" />
       <param name="mr.GitVersion.updateAssemblyInfo" value="false" spec="checkbox checkedValue='true' description='Update any AssemblyInfo files while running the Executable or MSBuild file?' display='normal' label='Update AssemblyInfo Files:' uncheckedValue='false'" />
+      <param name="mr.GitVersion.updateGitVersion" value="false" spec="checkbox checkedValue='true' description='Use Chocolatey to check whether a new version of GitVersion is available?' display='normal' label='Update GitVersion:' uncheckedValue='false'" />
     </parameters>
     <build-runners>
       <runner name="GitVersion" type="jetbrains_powershell">
@@ -41,7 +42,8 @@ Param (
     [string] $execArgs = '%mr.GitVersion.execArgs%',
     [string] $proj = '%mr.GitVersion.proj%',
     [string] $projArgs = '%mr.GitVersion.projArgs%',
-    [string] $updateAssemblyInfo = '%mr.GitVersion.updateAssemblyInfo%'
+    [string] $updateAssemblyInfo = '%mr.GitVersion.updateAssemblyInfo%',
+    [string] $updateGitVersion = '%mr.GitVersion.updateGitVersion%'
 )
 
 $ErrorActionPreference = "Stop"
@@ -127,9 +129,11 @@ try {
     if (-not (Test-Path $gitversion)) {
         $gitversion = Join-Path $chocolateyBinDir "gitversion.exe"
     }
+	
+    $choco = Join-Path (Join-Path $chocolateyDir "chocolateyInstall") "chocolatey.cmd"
+	
     if (-not (Test-Path $gitversion)) {
         Write-Host "##teamcity[progressMessage 'GitVersion not installed; installing GitVersion']"
-        $choco = Join-Path (Join-Path $chocolateyDir "chocolateyInstall") "chocolatey.cmd"
         iex "$choco install gitversion.portable"
         if ($LASTEXITCODE -ne 0) {
             throw "Error installing GitVersion"
@@ -138,6 +142,16 @@ try {
         Write-Host "GitVersion already installed"
     }
 
+    if ($updateGitVersion -eq "true") {
+        Write-Host "##teamcity[progressMessage 'Checking for updated version of GitVersion']"
+        iex "$choco update gitversion.portable"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Error updating GitVersion"
+        }
+    } else {
+        Write-Host "GitVersion will not be updated"
+    }
+	
     $outputFile = Join-ToWorkingDirectoryIfSpecified $outputFile
     $logFile = Join-ToWorkingDirectoryIfSpecified $logFile
     $exec = Join-ToWorkingDirectoryIfSpecified $exec

--- a/gitversion/test/GitVersion.ps1
+++ b/gitversion/test/GitVersion.ps1
@@ -12,7 +12,8 @@ Param (
     [string] $execArgs = '%mr.GitVersion.execArgs%',
     [string] $proj = '%mr.GitVersion.proj%',
     [string] $projArgs = '%mr.GitVersion.projArgs%',
-    [string] $updateAssemblyInfo = '%mr.GitVersion.updateAssemblyInfo%'
+    [string] $updateAssemblyInfo = '%mr.GitVersion.updateAssemblyInfo%',
+    [string] $updateGitVersion = '%mr.GitVersion.updateGitVersion%'
 )
 
 $ErrorActionPreference = "Stop"
@@ -97,9 +98,11 @@ try {
     if (-not (Test-Path $gitversion)) {
         $gitversion = Join-Path $chocolateyBinDir "gitversion.exe"
     }
+	
+    $choco = Join-Path (Join-Path $chocolateyDir "chocolateyInstall") "chocolatey.cmd"
+	
     if (-not (Test-Path $gitversion)) {
         Write-Host "##teamcity[progressMessage 'GitVersion not installed; installing GitVersion']"
-        $choco = Join-Path (Join-Path $chocolateyDir "chocolateyInstall") "chocolatey.cmd"
         iex "$choco install gitversion.portable"
         if ($LASTEXITCODE -ne 0) {
             throw "Error installing GitVersion"
@@ -107,6 +110,16 @@ try {
     } else {
         Write-Host "GitVersion already installed"
     }
+
+    if ($updateGitVersion -eq "true") {
+        Write-Host "##teamcity[progressMessage 'Checking for updated version of GitVersion']"
+        iex "$choco update gitversion.portable"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Error updating GitVersion"
+        }
+    } else {
+        Write-Host "GitVersion will not be updated"
+    }	
 
     $outputFile = Join-ToWorkingDirectoryIfSpecified $outputFile
     $logFile = Join-ToWorkingDirectoryIfSpecified $logFile


### PR DESCRIPTION
Added an additional checkbox to the Meta Runner Configuration to allow the running of:

`choco update gitversion.portable`

during the build.  Obviously, this is not something that you woul want to run on each build (as this will add time to the overall build), but from time to time, or when you know there is an update available, a simple modification to the build step can make this happen.
