### PR TITLE
Updated to use version 0.6.0 of GitRelaseNotes package

### DIFF
--- a/bitbucketreleasenotes/MRPP_BitBucketReleaseNotes.xml
+++ b/bitbucketreleasenotes/MRPP_BitBucketReleaseNotes.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<meta-runner name="Generate GitHub Release Notes">
+  <description>Generate GitHub Release Notes</description>
+  <settings>
+    <parameters>
+      <param name="mr.GenerateGitReleaseNotes.Repository" value="" spec="text description='The GitHub repository to generate release notes for, e.g. maartenba/repo1.' display='normal' label='Repository:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.ConsumerKey" value="" spec="text description='BitBuckets Consumer Key used for Oauth authentication' display='normal' label='BitBucket Consumer Key:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.ConsumerSecretKey" value="" spec="text description='BitBuckets Consumer Secret Key used for Oauth authentication' display='normal' label='BitBucket Consumer Secret:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Username" value="" spec="text description='Issue tracker username.' display='normal' label='Username:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Password" value="" spec="password description='Issue tracker password.' display='normal' label='Password:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.OutputFile" value="%teamcity.build.workingDir%\releasenotes.md" spec="text description='Specified the file in which release notes are generated.' display='normal' label='Output File:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.AllTags" value="false" spec="checkbox checkedValue='true' uncheckedValue='false' description='Specifies that all tags should be included in the release notes, if not specified then only the issues since the last tag are included.' display='normal' label='All Tags:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Version" value="" spec="text description='Specifies the version to publish.' display='normal' label='Version:' validationMode='any'" />
+      </parameters>
+    <build-runners>
+      <runner id="RUNNER_14" name="" type="Ant">
+        <parameters>
+          <param name="build-file">
+    <![CDATA[<project name="MetaRunner">
+
+<property name="mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion" value="0.6.0" />
+
+<target name="run" depends="downloadExecutable,runExecutable">
+</target>
+
+<target name="downloadExecutable">
+  <echo>Downloading and extracting latest GitReleaseNotes.exe...</echo>
+  <exec executable="%teamcity.tool.NuGet.CommandLine.DEFAULT.nupkg%\tools\NuGet.exe" dir="${teamcity.build.tempDir}" failonerror="false">
+    <arg line="install GitReleaseNotes -Version ${mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion} -OutputDirectory &quot;${teamcity.build.tempDir}\packages&quot;"/>
+  </exec>  
+  <echo>Downloaded and extracted latest GitReleaseNotes.exe.</echo>
+</target>
+
+<target name="runExecutable">
+  <echo>Running GitReleaseNotes.exe...</echo>
+  <echo>The command is.... /WorkingDirectory ${teamcity.build.workingDir} /IssueTracker BitBucket /Repo %mr.GenerateGitReleaseNotes.Repository% /OutputFile %mr.GenerateGitReleaseNotes.OutputFile% /Username %mr.GenerateGitReleaseNotes.Username% /Password %mr.GenerateGitReleaseNotes.Password% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Version %mr.GenerateGitReleaseNotes.Version% /ConsumerKey %mr.GenerateGitReleaseNotes.ConsumerKey% /ConsumerSecretKey %mr.GenerateGitReleaseNotes.ConsumerSecretKey% /Verbose true  </echo>
+  <exec executable="${teamcity.build.tempDir}\packages\GitReleaseNotes.${mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion}\tools\GitReleaseNotes.exe" dir="${teamcity.build.workingDir}" failonerror="false">
+    <arg line='/WorkingDirectory ${teamcity.build.workingDir} /IssueTracker BitBucket /Repo %mr.GenerateGitReleaseNotes.Repository% /OutputFile %mr.GenerateGitReleaseNotes.OutputFile% /Username %mr.GenerateGitReleaseNotes.Username% /Password %mr.GenerateGitReleaseNotes.Password% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Version %mr.GenerateGitReleaseNotes.Version% /ConsumerKey %mr.GenerateGitReleaseNotes.ConsumerKey% /ConsumerSecretKey %mr.GenerateGitReleaseNotes.ConsumerSecretKey% /Verbose true '/>
+</exec>
+  <echo>Finished running GitReleaseNotes.exe.</echo>
+</target>
+
+
+</project>]]></param>
+          <param name="build-file-path" value="build.xml" />
+          <param name="target" value="run" />
+          <param name="teamcity.coverage.emma.include.source" value="true" />
+          <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*" />
+          <param name="teamcity.coverage.idea.includePatterns" value="*" />
+          <param name="teamcity.step.mode" value="default" />
+          <param name="use-custom-build-file" value="true" />
+        </parameters>
+      </runner>
+    </build-runners>
+    <requirements />
+  </settings>
+</meta-runner>

--- a/bitbucketreleasenotes/README.md
+++ b/bitbucketreleasenotes/README.md
@@ -1,0 +1,26 @@
+# BitBucket Release Notes #
+
+Generates a release notes markdown file in the GitHub output format.
+
+## Parameter List ##
+
+- **ConsumerKey** BitBuckets Consumer Key used for Oauth authentication
+- **ConsumerSecretKey** BitBuckets Consumer Secret Key used for Oauth authentication
+- **Username** Can be used instead of Consumer Key/Secret. The username to authenticate with
+- **Password** Can be used instead of Consumer Key/Secret. The username to authenticate with
+- **Output File** Specifies the file in which release notes are generated
+- **Repo** Repository name, in Organisation/Repository format
+- **All Tags** Specifies that all tags should be included in the release notes, if not specified then only the issues since the last tag are included
+- **Version** Specifies the version to publish - i.e. The name of the Version you are publishing and want these release notes to be labelled as. (e.g. v1.2-beta)
+
+
+
+## Dependencies ##
+
+### NuGet packages ###
+
+- GitReleaseNotes - 0.6.0
+
+The Exe tool in the GitReleaseNotes package is downloaded and run. See this repo for more information.
+
+[https://github.com/JakeGinnivan/GitReleaseNotes](https://github.com/JakeGinnivan/GitReleaseNotes)

--- a/githubreleasenotes/MRPP_GitReleaseNotes.xml
+++ b/githubreleasenotes/MRPP_GitReleaseNotes.xml
@@ -6,24 +6,14 @@
       <param name="mr.GenerateGitReleaseNotes.Repository" value="" spec="text description='The GitHub repository to generate release notes for, e.g. maartenba/repo1.' display='normal' label='Repository:' validationMode='any'" />
       <param name="mr.GenerateGitReleaseNotes.Token" value="" spec="text description='GitHub OAuth2 token which can be used to connect to the GitHub repository.' display='normal' label='OAuth2 token:' validationMode='any'" />
       <param name="mr.GenerateGitReleaseNotes.OutputFile" value="%teamcity.build.workingDir%\releasenotes.md" spec="text description='Specified the file in which release notes are generated.' display='normal' label='Output File:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.ProjectId" value="" spec="text description='Issue tracker project ID.' display='normal' label='Project Id:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.IssueTracker" value="GitHub" spec="text description='Specifies the issue tracker used, possible Options: GitHub, Jira, YouTrack, BitBucket.' display='normal' label='Issue Tracker:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.Username" value="" spec="text description='Issue tracker username.' display='normal' label='Username:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.Password" value="" spec="password description='Issue tracker password.' display='normal' label='Password:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.JiraServer" value="" spec="text description='Url of Jira server.' display='normal' label='Jira Server:' validationMode='any'" />
       <param name="mr.GenerateGitReleaseNotes.AllTags" value="false" spec="checkbox checkedValue='true' uncheckedValue='false' description='Specifies that all tags should be included in the release notes, if not specified then only the issues since the last tag are included.' display='normal' label='All Tags:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.Jql" value="" spec="text description='Jql query for closed issues' display='normal' label='Jql:' validationMode='any'" />
       <param name="mr.GenerateGitReleaseNotes.Version" value="" spec="text description='Specifies the version to publish.' display='normal' label='Version:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.YouTrackServer" value="" spec="text description='Url of YouTrack server' display='normal' label='YouTrack server URL:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.YouTrackFilter" value="" spec="text description='YouTrack filter for closed issues that you would like included if mentioned.' display='normal' label='YouTrack Filter:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.ConsumerKey" value="" spec="text description='BitBuckets Consumer Key used for Oauth authentication' display='normal' label='BitBucket Consumer Key:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.ConsumerSecretKey" value="" spec="text description='BitBuckets Consumer Secret Key used for Oauth authentication' display='normal' label='BitBucket Consumer Secret:' validationMode='any'" />
-      <param name="mr.GenerateGitReleaseNotes.Verbose" value="false" spec="checkbox checkedValue='true' uncheckedValue='false' description='Enables verbose logging.' display='normal' label='Verbose:' validationMode='any'" />
-    </parameters>
+      </parameters>
     <build-runners>
       <runner id="RUNNER_14" name="" type="Ant">
         <parameters>
-          <param name="build-file"><![CDATA[<project name="MetaRunner">
+          <param name="build-file">
+    <![CDATA[<project name="MetaRunner">
 
 <property name="mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion" value="0.6.0" />
 
@@ -40,9 +30,9 @@
 
 <target name="runExecutable">
   <echo>Running GitReleaseNotes.exe...</echo>
-  <echo>The command is.... /WorkingDirectory &quot;${teamcity.build.workingDir}&quot; /IssueTracker %mr.GenerateGitReleaseNotes.IssueTracker% /Repo %mr.GenerateGitReleaseNotes.Repository% /Token %mr.GenerateGitReleaseNotes.Token% /OutputFile &quot;%mr.GenerateGitReleaseNotes.OutputFile%&quot; /ProjectId %mr.GenerateGitReleaseNotes.ProjectId% /Username %mr.GenerateGitReleaseNotes.Username% /Password %mr.GenerateGitReleaseNotes.Password% /JiraServer %mr.GenerateGitReleaseNotes.JiraServer% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Jql &quot;%mr.GenerateGitReleaseNotes.Jql%&quot; /Version %mr.GenerateGitReleaseNotes.Version% /YouTrackServer %mr.GenerateGitReleaseNotes.YouTrackServer% /YouTrackFilter %mr.GenerateGitReleaseNotes.YouTrackFilter% /ConsumerKey %mr.GenerateGitReleaseNotes.ConsumerKey% /ConsumerSecretKey %mr.GenerateGitReleaseNotes.ConsumerSecretKey% /Verbose %mr.GenerateGitReleaseNotes.Verbose% </echo>
-  <exec executable="${teamcity.build.tempDir}\packages\GitReleaseNotesEx.${mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion}\tools\GitReleaseNotes.exe" dir="${teamcity.build.workingDir}" failonerror="false">
-    <arg line='/WorkingDirectory ${teamcity.build.workingDir} /IssueTracker %mr.GenerateGitReleaseNotes.IssueTracker% /Repo %mr.GenerateGitReleaseNotes.Repository% /Token %mr.GenerateGitReleaseNotes.Token% /OutputFile %mr.GenerateGitReleaseNotes.OutputFile% /ProjectId %mr.GenerateGitReleaseNotes.ProjectId% /Username %mr.GenerateGitReleaseNotes.Username% /Password %mr.GenerateGitReleaseNotes.Password% /JiraServer %mr.GenerateGitReleaseNotes.JiraServer% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Jql &quot;%mr.GenerateGitReleaseNotes.Jql%&quot; /Version %mr.GenerateGitReleaseNotes.Version% /YouTrackServer %mr.GenerateGitReleaseNotes.YouTrackServer% /YouTrackFilter %mr.GenerateGitReleaseNotes.YouTrackFilter% /ConsumerKey %mr.GenerateGitReleaseNotes.ConsumerKey% /ConsumerSecretKey %mr.GenerateGitReleaseNotes.ConsumerSecretKey% /Verbose %mr.GenerateGitReleaseNotes.Verbose% '/>
+  <echo>The command is.... /WorkingDirectory ${teamcity.build.workingDir} /IssueTracker GitHub /Repo %mr.GenerateGitReleaseNotes.Repository% /Token %mr.GenerateGitReleaseNotes.Token% /OutputFile %mr.GenerateGitReleaseNotes.OutputFile% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Version %mr.GenerateGitReleaseNotes.Version% /Verbose %mr.GenerateGitReleaseNotes.Verbose% </echo>
+  <exec executable="${teamcity.build.tempDir}\packages\GitReleaseNotes.${mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion}\tools\GitReleaseNotes.exe" dir="${teamcity.build.workingDir}" failonerror="false">
+    <arg line='/WorkingDirectory ${teamcity.build.workingDir} /IssueTracker GitHub /Repo %mr.GenerateGitReleaseNotes.Repository% /Token %mr.GenerateGitReleaseNotes.Token% /OutputFile %mr.GenerateGitReleaseNotes.OutputFile% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Version %mr.GenerateGitReleaseNotes.Version% /Verbose %mr.GenerateGitReleaseNotes.Verbose% '/>
   </exec>
   <echo>Finished running GitReleaseNotes.exe.</echo>
 </target>

--- a/githubreleasenotes/MRPP_GitReleaseNotes.xml
+++ b/githubreleasenotes/MRPP_GitReleaseNotes.xml
@@ -3,16 +3,29 @@
   <description>Generate GitHub Release Notes</description>
   <settings>
     <parameters>
-      <param name="mr.GenerateGitReleaseNotes.Repository" value="" spec="text description='The GitHub repository to generate release notes for, e.g. maartenba/repo1.' display='normal' label='Repository:' validationMode='notempty'" />
-      <param name="mr.GenerateGitReleaseNotes.Token" value="" spec="text description='GitHub OAuth2 token which can be used to connect to the GitHub repository.' display='normal' label='OAuth2 token:' validationMode='notempty'" />
+      <param name="mr.GenerateGitReleaseNotes.Repository" value="" spec="text description='The GitHub repository to generate release notes for, e.g. maartenba/repo1.' display='normal' label='Repository:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Token" value="" spec="text description='GitHub OAuth2 token which can be used to connect to the GitHub repository.' display='normal' label='OAuth2 token:' validationMode='any'" />
       <param name="mr.GenerateGitReleaseNotes.OutputFile" value="%teamcity.build.workingDir%\releasenotes.md" spec="text description='Specified the file in which release notes are generated.' display='normal' label='Output File:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.ProjectId" value="" spec="text description='Issue tracker project ID.' display='normal' label='Project Id:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.IssueTracker" value="GitHub" spec="text description='Specifies the issue tracker used, possible Options: GitHub, Jira, YouTrack, BitBucket.' display='normal' label='Issue Tracker:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Username" value="" spec="text description='Issue tracker username.' display='normal' label='Username:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Password" value="" spec="password description='Issue tracker password.' display='normal' label='Password:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.JiraServer" value="" spec="text description='Url of Jira server.' display='normal' label='Jira Server:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.AllTags" value="false" spec="checkbox checkedValue='true' uncheckedValue='false' description='Specifies that all tags should be included in the release notes, if not specified then only the issues since the last tag are included.' display='normal' label='All Tags:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Jql" value="" spec="text description='Jql query for closed issues' display='normal' label='Jql:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Version" value="" spec="text description='Specifies the version to publish.' display='normal' label='Version:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.YouTrackServer" value="" spec="text description='Url of YouTrack server' display='normal' label='YouTrack server URL:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.YouTrackFilter" value="" spec="text description='YouTrack filter for closed issues that you would like included if mentioned.' display='normal' label='YouTrack Filter:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.ConsumerKey" value="" spec="text description='BitBuckets Consumer Key used for Oauth authentication' display='normal' label='BitBucket Consumer Key:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.ConsumerSecretKey" value="" spec="text description='BitBuckets Consumer Secret Key used for Oauth authentication' display='normal' label='BitBucket Consumer Secret:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Verbose" value="false" spec="checkbox checkedValue='true' uncheckedValue='false' description='Enables verbose logging.' display='normal' label='Verbose:' validationMode='any'" />
     </parameters>
     <build-runners>
       <runner id="RUNNER_14" name="" type="Ant">
         <parameters>
           <param name="build-file"><![CDATA[<project name="MetaRunner">
 
-<property name="mr.GenerateGitReleaseNotes.GitReleaseNotes.Version" value="0.2.1" />
+<property name="mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion" value="0.6.0" />
 
 <target name="run" depends="downloadExecutable,runExecutable">
 </target>
@@ -20,16 +33,17 @@
 <target name="downloadExecutable">
   <echo>Downloading and extracting latest GitReleaseNotes.exe...</echo>
   <exec executable="%teamcity.tool.NuGet.CommandLine.DEFAULT.nupkg%\tools\NuGet.exe" dir="${teamcity.build.tempDir}" failonerror="false">
-    <arg line="install GitReleaseNotes -Version ${mr.GenerateGitReleaseNotes.GitReleaseNotes.Version} -OutputDirectory &quot;${teamcity.build.tempDir}\packages&quot;"/>
+    <arg line="install GitReleaseNotes -Version ${mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion} -OutputDirectory &quot;${teamcity.build.tempDir}\packages&quot;"/>
   </exec>  
   <echo>Downloaded and extracted latest GitReleaseNotes.exe.</echo>
 </target>
 
 <target name="runExecutable">
   <echo>Running GitReleaseNotes.exe...</echo>
-  <exec executable="${teamcity.build.tempDir}\packages\GitReleaseNotes.${mr.GenerateGitReleaseNotes.GitReleaseNotes.Version}\tools\GitReleaseNotes.exe" dir="${teamcity.build.workingDir}" failonerror="false">
-    <arg line="/WorkingDirectory &quot;${teamcity.build.workingDir}&quot; /IssueTracker Github /Repo &quot;%mr.GenerateGitReleaseNotes.Repository%&quot; /Token &quot;%mr.GenerateGitReleaseNotes.Token%&quot; /OutputFile &quot;%mr.GenerateGitReleaseNotes.OutputFile%&quot;"/>
-  </exec>  
+  <echo>The command is.... /WorkingDirectory &quot;${teamcity.build.workingDir}&quot; /IssueTracker %mr.GenerateGitReleaseNotes.IssueTracker% /Repo %mr.GenerateGitReleaseNotes.Repository% /Token %mr.GenerateGitReleaseNotes.Token% /OutputFile &quot;%mr.GenerateGitReleaseNotes.OutputFile%&quot; /ProjectId %mr.GenerateGitReleaseNotes.ProjectId% /Username %mr.GenerateGitReleaseNotes.Username% /Password %mr.GenerateGitReleaseNotes.Password% /JiraServer %mr.GenerateGitReleaseNotes.JiraServer% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Jql &quot;%mr.GenerateGitReleaseNotes.Jql%&quot; /Version %mr.GenerateGitReleaseNotes.Version% /YouTrackServer %mr.GenerateGitReleaseNotes.YouTrackServer% /YouTrackFilter %mr.GenerateGitReleaseNotes.YouTrackFilter% /ConsumerKey %mr.GenerateGitReleaseNotes.ConsumerKey% /ConsumerSecretKey %mr.GenerateGitReleaseNotes.ConsumerSecretKey% /Verbose %mr.GenerateGitReleaseNotes.Verbose% </echo>
+  <exec executable="${teamcity.build.tempDir}\packages\GitReleaseNotesEx.${mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion}\tools\GitReleaseNotes.exe" dir="${teamcity.build.workingDir}" failonerror="false">
+    <arg line='/WorkingDirectory ${teamcity.build.workingDir} /IssueTracker %mr.GenerateGitReleaseNotes.IssueTracker% /Repo %mr.GenerateGitReleaseNotes.Repository% /Token %mr.GenerateGitReleaseNotes.Token% /OutputFile %mr.GenerateGitReleaseNotes.OutputFile% /ProjectId %mr.GenerateGitReleaseNotes.ProjectId% /Username %mr.GenerateGitReleaseNotes.Username% /Password %mr.GenerateGitReleaseNotes.Password% /JiraServer %mr.GenerateGitReleaseNotes.JiraServer% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Jql &quot;%mr.GenerateGitReleaseNotes.Jql%&quot; /Version %mr.GenerateGitReleaseNotes.Version% /YouTrackServer %mr.GenerateGitReleaseNotes.YouTrackServer% /YouTrackFilter %mr.GenerateGitReleaseNotes.YouTrackFilter% /ConsumerKey %mr.GenerateGitReleaseNotes.ConsumerKey% /ConsumerSecretKey %mr.GenerateGitReleaseNotes.ConsumerSecretKey% /Verbose %mr.GenerateGitReleaseNotes.Verbose% '/>
+  </exec>
   <echo>Finished running GitReleaseNotes.exe.</echo>
 </target>
 

--- a/githubreleasenotes/README.md
+++ b/githubreleasenotes/README.md
@@ -1,1 +1,21 @@
-TODO - https://github.com/JakeGinnivan/GitReleaseNotes
+# GitHub Release Notes #
+
+Generates a release notes markdown file in the GitHub output format.
+
+## Parameter List ##
+
+- **Repository** The GitHub repository to generate release notes for, e.g. maartenba/repo1.
+- **OAuth2 token** GitHub OAuth2 token which can be used to connect to the GitHub repository
+- **Output File** Specifies the file in which release notes are generated
+- **All Tags** Specifies that all tags should be included in the release notes, if not specified then only the issues since the last tag are included
+- **Version** Specifies the version to publish - i.e. The name of the Version you are publishing and want these release notes to be labelled as. (e.g. v1.2-beta)
+
+## Dependencies ##
+
+### NuGet packages ###
+
+- GitReleaseNotes - 0.6.0
+
+The Exe tool in the GitReleaseNotes package is downloaded and run. See this repo for more information.
+
+[https://github.com/JakeGinnivan/GitReleaseNotes](https://github.com/JakeGinnivan/GitReleaseNotes)

--- a/jirareleasenotes/MRPP_JIRAReleaseNotes.xml
+++ b/jirareleasenotes/MRPP_JIRAReleaseNotes.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<meta-runner name="Generate GitHub Release Notes">
+  <description>Generate JIRA Release Notes</description>
+  <settings>
+    <parameters>
+      <param name="mr.GenerateGitReleaseNotes.JiraServer" value="" spec="text description='Url of Jira server.' display='normal' label='Jira Server:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.ProjectId" value="" spec="text description='Issue tracker project ID.' display='normal' label='Project Id:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Jql" value="" spec="text description='Jql query for closed issues' display='normal' label='Jql:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.OutputFile" value="%teamcity.build.workingDir%\releasenotes.md" spec="text description='Specifies the file in which release notes are generated.' display='normal' label='Output File:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Username" value="" spec="text description='Issue tracker username.' display='normal' label='Username:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Password" value="" spec="password description='Issue tracker password.' display='normal' label='Password:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.AllTags" value="false" spec="checkbox checkedValue='true' uncheckedValue='false' description='Specifies that all tags should be included in the release notes, if not specified then only the issues since the last tag are included.' display='normal' label='All Tags:' validationMode='any'" />
+      <param name="mr.GenerateGitReleaseNotes.Version" value="" spec="text description='Specifies the version to publish.' display='normal' label='Version:' validationMode='any'" />
+    </parameters>
+    <build-runners>
+      <runner id="RUNNER_14" name="" type="Ant">
+        <parameters>
+          <param name="build-file">
+            <![CDATA[<project name="MetaRunner">
+
+<property name="mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion" value="0.6.0" />
+
+<target name="run" depends="downloadExecutable,runExecutable">
+</target>
+
+<target name="downloadExecutable">
+  <echo>Downloading and extracting latest GitReleaseNotes.exe...</echo>
+  <exec executable="%teamcity.tool.NuGet.CommandLine.DEFAULT.nupkg%\tools\NuGet.exe" dir="${teamcity.build.tempDir}" failonerror="false">
+    <arg line="install GitReleaseNotes -Version ${mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion} -OutputDirectory &quot;${teamcity.build.tempDir}\packages&quot;"/>
+  </exec>  
+  <echo>Downloaded and extracted latest GitReleaseNotes.exe.</echo>
+</target>
+
+<target name="runExecutable">
+  <echo>Running GitReleaseNotes.exe...</echo>
+  <echo>The command is.... /WorkingDirectory ${teamcity.build.workingDir} /IssueTracker Jira /OutputFile %mr.GenerateGitReleaseNotes.OutputFile% /ProjectId %mr.GenerateGitReleaseNotes.ProjectId% /Username %mr.GenerateGitReleaseNotes.Username% /Password %mr.GenerateGitReleaseNotes.Password% /JiraServer %mr.GenerateGitReleaseNotes.JiraServer% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Jql &quot;%mr.GenerateGitReleaseNotes.Jql%&quot; /Version %mr.GenerateGitReleaseNotes.Version% /Verbose true </echo>
+  <exec executable="${teamcity.build.tempDir}\packages\GitReleaseNotes.${mr.GenerateGitReleaseNotes.GitReleaseNotes.NugetVersion}\tools\GitReleaseNotes.exe" dir="${teamcity.build.workingDir}" failonerror="false">
+    <arg line='/WorkingDirectory ${teamcity.build.workingDir} /IssueTracker Jira /OutputFile %mr.GenerateGitReleaseNotes.OutputFile% /ProjectId %mr.GenerateGitReleaseNotes.ProjectId% /Username %mr.GenerateGitReleaseNotes.Username% /Password %mr.GenerateGitReleaseNotes.Password% /JiraServer %mr.GenerateGitReleaseNotes.JiraServer% /AllTags %mr.GenerateGitReleaseNotes.AllTags% /Jql &quot;%mr.GenerateGitReleaseNotes.Jql%&quot; /Version %mr.GenerateGitReleaseNotes.Version% /Verbose true '/>
+  </exec>
+  <echo>Finished running GitReleaseNotes.exe.</echo>
+</target>
+
+
+</project>]]>
+          </param>
+          <param name="build-file-path" value="build.xml" />
+          <param name="target" value="run" />
+          <param name="teamcity.coverage.emma.include.source" value="true" />
+          <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*" />
+          <param name="teamcity.coverage.idea.includePatterns" value="*" />
+          <param name="teamcity.step.mode" value="default" />
+          <param name="use-custom-build-file" value="true" />
+        </parameters>
+      </runner>
+    </build-runners>
+    <requirements />
+  </settings>
+</meta-runner>

--- a/jirareleasenotes/README.md
+++ b/jirareleasenotes/README.md
@@ -1,0 +1,25 @@
+# JIRA Release Notes #
+
+Generates a release notes markdown file in the GitHub output format.
+
+## Parameter List ##
+
+- **Jira Server** The Url of Jira server
+- **Project Id** Issue tracker project ID
+- **Jql** Jql query for closed issues
+- **Output File** Specifies the file in which release notes are generated
+- **Username** The username to authenticate to the JIRA server with
+- **Password** The password to authenticate to the JIRA server with
+- **All Tags** Specifies that all tags should be included in the release notes, if not specified then only the issues since the last tag are included
+- **Version** Specifies the version to publish - i.e. The name of the Version you are publishing and want these release notes to be labelled as. (e.g. v1.2-beta)
+
+
+## Dependencies ##
+
+### NuGet packages ###
+
+- GitReleaseNotes - 0.6.0
+
+The Exe tool in the GitReleaseNotes package is downloaded and run. See this repo for more information.
+
+[https://github.com/JakeGinnivan/GitReleaseNotes](https://github.com/JakeGinnivan/GitReleaseNotes)


### PR DESCRIPTION
Latest version of GitReleaseNotes supports other issue trackers such as Youtrack, JIRA, BitBucket, etc. 

Added all the parameters available in the GitReleaseNotes project as meta runner parameters in TeamCity

 Note: When using the JQL parameter in Team City you must escape quotation marks with &quot;

