### PR TITLE
Update for xUnit 2.0. 

### DIFF
--- a/xunit.net/MR_XUnitNet.xml
+++ b/xunit.net/MR_XUnitNet.xml
@@ -3,8 +3,8 @@
   <description>Run xUnit.net tests with dotCover coverage</description>
   <settings>
     <parameters>
-        <param name="mr.XUnitNet.assembliesToTest" value="" spec="text description='The assembly/ies to test; relative to the working directory.' display='normal' label='Assembly/ies to test:'" />
-        <param name="mr.XUnitNet.dotCoverFilters" value="" spec="text description='Any dotCover filters to apply.' display='normal' label='dotCover filters:'" />
+      <param name="mr.XUnitNet.assembliesToTest" value="" spec="text validationMode='any' description='The assembly/ies to test; relative to the working directory.' display='normal' label='Assembly/ies to test:'" />
+      <param name="mr.XUnitNet.dotCoverFilters" value="" spec="text description='Any dotCover filters to apply.' display='normal' label='dotCover filters:'" />
     </parameters>
     <build-runners>
       <runner name="Install xUnit from Chocolatey" type="jetbrains_powershell">
@@ -15,8 +15,7 @@
           <param name="jetbrains_powershell_script_mode" value="CODE" />
           <param name="jetbrains_powershell_bitness" value="x86" />
           <param name="teamcity.step.mode" value="default" />
-          <param name="jetbrains_powershell_script_code"><![CDATA[
-[CmdletBinding()]
+          <param name="jetbrains_powershell_script_code"><![CDATA[[CmdletBinding()]
 Param (
     [string] $workingDir = "%teamcity.build.workingDir%"
 )
@@ -24,16 +23,14 @@ Param (
 $ErrorActionPreference = "Stop"
 
 try {
-
     $chocolateyDir = $null
-    #if ($env:ChocolateyInstall -ne $null) {
-    #    $chocolateyDir = $env:ChocolateyInstall
-    #} elseif (Test-Path (Join-Path $env:SYSTEMDRIVE Chocolatey)) {
-    #    $chocolateyDir = Join-Path $env:SYSTEMDRIVE Chocolatey
-    #} elseif (Test-Path (Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey)) {
-    #    $chocolateyDir = Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey
-    #}
-    $chocolateyDir = "C:\ProgramData\Chocolatey"
+    if ($env:ChocolateyInstall -ne $null) {
+        $chocolateyDir = $env:ChocolateyInstall
+    } elseif (Test-Path (Join-Path $env:SYSTEMDRIVE Chocolatey)) {
+        $chocolateyDir = Join-Path $env:SYSTEMDRIVE Chocolatey
+    } elseif (Test-Path (Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey)) {
+        $chocolateyDir = Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey
+    }
     
     if ($chocolateyDir -eq $null) {
         Write-Host "##teamcity[progressMessage 'Chocolatey not installed; installing Chocolatey']"
@@ -46,20 +43,20 @@ try {
         Write-Host "Chocolatey already installed"
     }
 
-    if ($chocolateyDir -ne "C:\ProgramData\Chocolatey") {
+    if ($chocolateyDir -ne "%env.ProgramData%\Chocolatey") {
         throw "Make sure you are running the latest version of Chocolatey and it's installed to C:\ProgramData\Chocolatey; see known limitations at https://github.com/JetBrains/meta-runner-power-pack/xunit.net"
+	}
+	
+    $chocolateyBinDir = Join-Path $chocolateyDir "bin"
+    $xunit = Join-Path $chocolateyBinDir "xunit.console.bat"
+    if (-not (Test-Path $xunit)) {
+        $xunit = Join-Path $chocolateyBinDir "xunit.console.exe"
     }
 
-    $chocolateyBinDir = Join-Path $chocolateyDir "bin"
-    #$xunit = Join-Path $chocolateyBinDir "xunit.console.clr4.bat"
-    #if (-not (Test-Path $xunit)) {
-    #    $xunit = Join-Path $chocolateyBinDir "xunit.console.clr4.exe"
-    #}
-    $xunit = Join-Path $chocolateyBinDir "xunit.console.clr4.exe"
     if (-not (Test-Path $xunit)) {
         Write-Host "##teamcity[progressMessage 'xUnit.net not installed; installing xUnit.net']"
         $choco = Join-Path (Join-Path $chocolateyDir "chocolateyInstall") "chocolatey.cmd"
-        iex "$choco install xunit"
+        iex "$choco install xunit -version 2.0.0"
         if ($LASTEXITCODE -ne 0) {
             throw "Error installing xUnit.net"
         }
@@ -67,14 +64,12 @@ try {
         Write-Host "xUnit.net already installed"
     }
 
-    #Write-Host "##teamcity[setParameter name='mr.XUnitNet.exe' value='$xunit']"
 }
 catch {
     Write-Host "##teamcity[buildStatus text='$_' status='FAILURE']"
     Write-Host "##teamcity[message text='$_' status='ERROR']"
     exit 1
-}
-          ]]></param>
+}]]></param>
         </parameters>
       </runner>
       <runner name="Run xUnit.net tests" type="jetbrains.dotNetGenericRunner">
@@ -84,8 +79,7 @@ catch {
           <param name="dotNetTestRunner.Type" value="GenericProcess" />
           <param name="proc_additional_commandline">%mr.XUnitNet.assembliesToTest%</param>
           <param name="proc_bit" value="MSIL" />
-	  <!--<param name="proc_path" value="%mr.XUnitNet.exe%" />-->
-	  <param name="proc_path" value="C:\ProgramData\Chocolatey\bin\xunit.console.clr4.exe" />
+          <param name="proc_path" value="%env.ProgramData%\chocolatey\bin\xunit.console.exe" />
           <param name="proc_runtime_version" value="v4.0" />
           <param name="teamcity.step.mode" value="default" />
         </parameters>

--- a/xunit.net/MR_XUnitNet.xml
+++ b/xunit.net/MR_XUnitNet.xml
@@ -44,7 +44,7 @@ try {
     }
 
     if ($chocolateyDir -ne "%env.ProgramData%\Chocolatey") {
-        throw "Make sure you are running the latest version of Chocolatey and it's installed to C:\ProgramData\Chocolatey; see known limitations at https://github.com/JetBrains/meta-runner-power-pack/xunit.net"
+        throw "Make sure you are running the latest version of Chocolatey and it's installed to %env.ProgramData%\Chocolatey; see known limitations at https://github.com/JetBrains/meta-runner-power-pack/xunit.net"
 	}
 	
     $chocolateyBinDir = Join-Path $chocolateyDir "bin"

--- a/xunit.net/README.md
+++ b/xunit.net/README.md
@@ -1,7 +1,7 @@
 xUnit.net meta-runner for TeamCity
 ==================================
 
-This meta-runner allows you to run [xUnit.net](https://github.com/xunit/xunit) tests inside of TeamCity without needing to install anything further on your server. It will automatically install the xUnit runner from Chocolatey after ensuring Chocolatey exists on that server (it installs Chocolatey for you if it's not already there). It will then execute xUnit against the dll(s) you provide and output the appropriate test statuses to TeamCity.
+This meta-runner allows you to run [xUnit.net](https://github.com/xunit/xunit) tests inside of TeamCity without needing to install anything further on your server. It will automatically install the xUnit runner from Chocolatey after ensuring Chocolatey exists on that server (it installs Chocolatey for you if it's not already there). It will then execute xUnit.net against the dll(s) you provide and output the appropriate test statuses to TeamCity.
 
 xUnit.net Runner
 ----------------
@@ -12,9 +12,14 @@ The following options can be specified:
 * Assembly/ies to test - The list of assemblies to test with paths relative to the working directory
 * dotCover Filters - List of filters for dotCover code coverage
 
+Supports both xUnit.net v1.x and v2.0 test assemblies, using the xUnit2.0 console runner.
+
 Known Issues
 ------------
 
-1. Once this gets an xunit installed on the server from Chocolatey it will never try and update it - It could include a call to cinst to update it if necessary every run, but that will add at least 1-2s (if not more) to every build run due to Chocolatey's slowness. That's why it checks the filesystem for chocolatey rather than invoking a Chocolatey command to see if it already exists.
-2. Due to difficulties passing dynamic variables between meta-runner runners this meta-runner only works with Chocolatey > 0.9.8.27 and where Chocolatey is installed to C:\ProgramData\Chocolatey
+1. Once this gets xUnit.net 2.x installed on the server from Chocolatey it will never try and update it - It could include a call to cinst to update it if necessary every run, but that will add at least 1-2s (if not more) to every build run due to Chocolatey's slowness. That's why it checks the filesystem for chocolatey rather than invoking a Chocolatey command to see if it already exists.
+2. Due to difficulties passing dynamic variables between meta-runner runners this meta-runner only works with Chocolatey > 0.9.8.27 and where Chocolatey is installed to %ProgramData%\Chocolatey.
 3. Currently this meta-runner is hardcoded to use dotCover
+4. This meta-runner is compatible with the xUnit.net 2.0 console runner and therefore forces an update to xUnit.net
+2.0. It does this by hard-coding the chocolatey package reference to XUnit 2.0.0 (which is currently in the package
+moderation queue).


### PR DESCRIPTION
* Installs xUnit 2.0.0 package (including over existing 1.x installs)
* Fix validation rules on assembly list so that specifying multiple test assemblies works as expected. 
* Remove hard-coded references to C:\ drive.
