### PR TITLE
Compatibility fix for Chocolatey v0.9.9.6

### DIFF
--- a/gitversion/MR_GitVersion.xml
+++ b/gitversion/MR_GitVersion.xml
@@ -130,11 +130,11 @@ try {
         $gitversion = Join-Path $chocolateyBinDir "gitversion.exe"
     }
 	
-    $choco = Join-Path (Join-Path $chocolateyDir "chocolateyInstall") "chocolatey.cmd"
+    $choco = Join-Path $chocolateyDir "choco.exe"
 	
     if (-not (Test-Path $gitversion)) {
         Write-Host "##teamcity[progressMessage 'GitVersion not installed; installing GitVersion']"
-        iex "$choco install gitversion.portable"
+        iex "$choco install gitversion.portable -y"
         if ($LASTEXITCODE -ne 0) {
             throw "Error installing GitVersion"
         }
@@ -144,7 +144,7 @@ try {
 
     if ($updateGitVersion -eq "true") {
         Write-Host "##teamcity[progressMessage 'Checking for updated version of GitVersion']"
-        iex "$choco update gitversion.portable"
+        iex "$choco update gitversion.portable -y"
         if ($LASTEXITCODE -ne 0) {
             throw "Error updating GitVersion"
         }


### PR DESCRIPTION
The chocolatey executable files were moved a couple of versions back breaking this meta-runner.

This change updates the path to the new location and appends the '-y' option to suppress the user confirmation to install the package.