### PR TITLE
value of phpunit.result.error can not be changed if phpunit fails, be…

### DIFF
--- a/php/MRPP_PHP_PHPUnit.xml
+++ b/php/MRPP_PHP_PHPUnit.xml
@@ -42,8 +42,6 @@
   <isfalse value="${phpunit.coverage.set}"/>
 </condition>
 
-<property name="phpunit.result.error" value="false" />
-
 <target name="runTests" depends="getPhpUnit,runPhpUnitPhar,runPhpUnitRuntime,collectCoverage">
   <fail message="Unit test error." if="${phpunit.result.error}" />
 </target>


### PR DESCRIPTION
…cause phpunit.result.error it's immutable

This line sets an immutable property ```phpunit.result.error```

    <property name="phpunit.result.error" value="false" />

When we get on return code > 0 in ```runPhpUnitRuntime```

```
<target name="runPhpUnitRuntime" depends="getPhpUnit" if="phpunit.runtime.set">
  ...
  <condition property="phpunit.result.error">
    <not>
      <equals arg1="0" arg2="${phpunit.result}"/>
    </not>
  </condition>
</target>
```

the property ```phpunit.result.error```can not be changed, and ```runTests``` can never fail

```
<target name="runTests" depends="getPhpUnit,runPhpUnitPhar,runPhpUnitRuntime,collectCoverage">
  <fail message="Unit test error." if="${phpunit.result.error}" />
</target>
```