### PR TITLE
Change how to parse a boolean variable.

### DIFF
--- a/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
+++ b/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
@@ -48,7 +48,7 @@ Param (
     [string] $xUnitNuget = "%xUnitNet.nugetSource%",
     [string] $xUnitExe = "%xUnitNet.executable%",
     [string] $dotCoverExecutable = "%teamcity.tool.dotCover%",
-    [boolean] $xunitLegacy = [boolean]"%xUnitNet.executable.legacymode%",
+    [boolean] $xunitLegacy = [System.Convert]::ToBoolean("%xUnitNet.executable.legacymode%"),
     [string] $assemblyFilter = "%xUnitNet.assembliesPath%",
     [string] $traits = "%xUnitNet.trait%",
     [string] $notraits = "%xUnitNet.notrait%",


### PR DESCRIPTION
I began to use this runner. I found than the variable is parsed always to True.

Then I propose this little change.

Reference:
http://www.jonathanmedd.net/2012/05/powershell-quick-tip-converting-a-string-to-a-boolean-value.html