### PR TITLE
Avoid a null reference exception in xUnit.net-dotCover Meta Runner when there are no test assemblies

### DIFF
--- a/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
+++ b/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
@@ -75,7 +75,15 @@ try {
 	
   ## Search for the assemblies using wildcard pattern
   $assemblies = (Get-ChildItem $assemblyFilter -Recurse | select -ExpandProperty FullName)
-  Write-Host "Found test assemblies: " $assemblies
+  if($assemblies -eq $null)
+  {
+    Write-Host "No test assemblies found"
+    return
+  }
+  else
+  {
+    Write-Host "Found test assemblies: " $assemblies
+  }
   
   ## create single-line correctly formatted xunit argument 
   # split multi-line xunit args into single line and correctly format


### PR DESCRIPTION
Running the xUnit.net-dotCover Meta Runner as a build step when there are no matching xUnit test assemblies results in a null reference exception and a failed build.

Probably not a big real-world issue, but it's a simple fix...

(I hit it on a TEST TeamCity server while trying out the xUnit.net-dotCover runner installation process on a new, empty build configuration as a precursor to pushing it onto our PROD TeamCity server).