### PR TITLE
#65 Allow ant-style wildcards to work in XUnit+dotCover runner

### DIFF
--- a/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
+++ b/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
@@ -75,6 +75,7 @@ try {
 	
   ## Search for the assemblies using wildcard pattern
   $assemblies = (Get-ChildItem $assemblyFilter -Recurse | select -ExpandProperty FullName)
+
   if($assemblies -eq $null)
   {
     Write-Host "No test assemblies found"
@@ -86,8 +87,15 @@ try {
   }
   
   ## create single-line correctly formatted xunit argument 
+
+  ## the type will be a string for a single-line path without a wildcard.
+  if ($assemblies.GetType() -eq [String])
+  {
+    $assemblies = [String[]] $assemblies
+  }
+
   # split multi-line xunit args into single line and correctly format
-  $assemblyArg = $assemblies.Trim() -Join " "
+  $assemblyArg = [String]::Join(" ", $assemblies)
   If($traits.Length -gt 0) {
     $traitArg = ($traits.Trim().Split("`r`n") | where {$_ -ne ""} | % { "-trait """+$_+""""}) -join " "
   }


### PR DESCRIPTION
Fixes #65 