### PR TITLE
Aid debugging when filters don't work

### DIFF
--- a/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
+++ b/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
@@ -88,7 +88,8 @@ try {
 
   if($assemblies -eq $null)
   {
-    Write-Host "No test assemblies found"
+    $cwd = Get-Location
+    Write-Host "No test assemblies found; cwd = $cwd ; assembly filter = $assemblyFilter"
     return
   }
   else


### PR DESCRIPTION
I typed a 'T' in another locale and it wouldn't find my tests, argh!