### PR TITLE
Support spaces in path to test assembly

### DIFF
--- a/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
+++ b/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
@@ -105,7 +105,7 @@ try {
   }
 
   # split multi-line xunit args into single line and correctly format
-  $assemblyArg = [String]::Join(" ", $assemblies)
+  $assemblyArg = "`"" + [String]::Join("`" `"", $assemblies) + "`""
   If($traits.Length -gt 0) {
     $traitArg = ($traits.Trim().Split("`r`n") | where {$_ -ne ""} | % { "-trait """+$_+""""}) -join " "
   }


### PR DESCRIPTION
This change will allow for spaces to be anywhere in the path to the test assemblies.