### PR TITLE
Trim leading and trailing whitespace from tags

### DIFF
--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -36,6 +36,18 @@
 /&gt;
 
 &lt;replaceregexp file="${tags.file}"
+               match="^\s+"
+               replace=""
+               flags="gm"
+/&gt;
+
+&lt;replaceregexp file="${tags.file}"
+               match="\s+$"
+               replace=""
+               flags="gm"
+/&gt;
+
+&lt;replaceregexp file="${tags.file}"
                match="(\s+)"
                replace="&amp;lt;/tag&gt;&amp;lt;tag&gt;"
                flags="gm"


### PR DESCRIPTION
This prevents an error when the tags are specified like this:
%BUILD_TYPE% %ADDITIONAL%

If %BUILD_TYPE% is "Quick" and %ADDITIONAL% is empty, TeamCity passes "-Dtags=Quick " to java.exe. The meta-runner converts it to `<tags><tag>Quick</tag><tag></tag></tags>`. This results in 400 http response and fails the build step.