### PR TITLE
Changed the way assemblyfilter is applied

### DIFF
--- a/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
+++ b/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
@@ -84,7 +84,7 @@ try {
   }
 	
    ## Search for the assemblies using wildcard pattern
-  $assemblies = (Get-ChildItem $assemblyFilter -Recurse | select -ExpandProperty FullName)
+  $assemblies = (Get-ChildItem . -Recurse | where {$_.FullName -like $assemblyFilter }| select -ExpandProperty FullName)
 
   if($assemblies -eq $null)
   {


### PR DESCRIPTION
It seems like the current way target assemblies is resolved is not working as expected. Fx. */bin/release/*test*.dll will not work, because you cant include directory path or directory path wildcards when using Get-ChildItem in that way.

I suggest here that the filter is moved to a where clause with the -like operator. Then you cant write */bin/release/*test*.dll in the assemblyFilter parameter (and not just *test*.dll).