### PR TITLE
Add AssemblyAttributesPatcher meta runner

### DIFF
--- a/dotnet/MRPP_DOTNET_AssemblyAttributesPatcher.xml
+++ b/dotnet/MRPP_DOTNET_AssemblyAttributesPatcher.xml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<meta-runner name="Assembly Attributes Patcher">
+  <description>Replace assembly ralated attributes' values</description>
+  <settings>
+    <parameters>
+      <param name="AssemblyVersion" value="" spec="text description='Specifies the version of the assembly being attributed.'" />
+      <param name="AssemblyFileVersion" value="" spec="text description='Instructs a compiler to use a specific version number for the Win32 file version resource.'" />
+      <param name="AssemblyInformationalVersion" value="" spec="text description='Defines additional version information for an assembly manifest.'" />
+    </parameters>
+    <build-runners>
+      <runner name="Replace assembly version" type="jetbrains_powershell">
+        <parameters>
+          <param name="jetbrains_powershell_bitness" value="x86" />
+          <param name="jetbrains_powershell_execution" value="PS1" />
+          <param name="jetbrains_powershell_script_code"><![CDATA[function Replace-String{
+    [CmdletBinding()]
+    param([Parameter(ValueFromPipeline)]$Path, $OldString, $NewString)
+    process{    
+        foreach($p in $path){
+            $content = Get-Content -Path $p -Raw  
+            $content -replace $OldString,$NewString | Set-Content -Path $p -Encoding UTF8 -Force
+            Write-Host "`t$p"
+        }
+    }
+}
+
+function Replace-AttributeValue($AttributeName, $Version){
+    if([String]::IsNullOrWhiteSpace($Version) -eq $false)
+    {
+        Write-Host "Set $AttributeName to $Version in:"
+        $pattern = "assembly\s*:\s*$AttributeName\(\s*`".*?`"\s*\)"
+        Get-ChildItem AssemblyInfo.cs -recurse |  select-string $pattern -List | Select-Object -ExpandProperty Path | Replace-String -OldString $pattern -NewString "assembly: $AttributeName(`"$Version`")"
+    }
+}
+
+Write-Host "AssemblyPatcher START in $(Get-Location)"
+Replace-AttributeValue -AttributeName "AssemblyVersion" -Version "%AssemblyVersion%"
+Replace-AttributeValue -AttributeName "AssemblyFileVersion" -Version "%AssemblyFileVersion%"
+Replace-AttributeValue -AttributeName "AssemblyInformationalVersion" -Version "%AssemblyInformationalVersion%"
+Write-Host "AssemblyPatcher FINISH"]]></param>
+          <param name="jetbrains_powershell_script_mode" value="CODE" />
+          <param name="teamcity.step.mode" value="default" />
+        </parameters>
+      </runner>
+    </build-runners>
+    <requirements />
+  </settings>
+</meta-runner>


### PR DESCRIPTION
I've added a meta-runner which works like "AssemblyInfo patcher" build feature but can be used as build step. The problem with build feature is that it runs before all build steps and there is no opportunity to dynamically change values for assembly attributes (ex. set different values base on parameters provided to build). With my meta-runner this is achievable in two simple steps
1) Add PS build step which modifies build variables
```ps
$branchVersion ="1.0"
switch("%branchpath%"){
 "trunk"{$branchVersion="3.0"}
 "branches/S16"{$branchVersion="2.0"}
 "branches/S09" {$branchVersion="1.0"}
}
Write-Host "##teamcity[buildNumber '$($branchVersion).%system.build.vcs.number%.%build.counter%']"
```
2) Add AssemblyAttributesPatcher build step and use modified variables as a input parameters