### PR TITLE
Added option to specify PHP executable path

### DIFF
--- a/php/MRPP_PHP_PHPUnit.xml
+++ b/php/MRPP_PHP_PHPUnit.xml
@@ -6,6 +6,7 @@
       <param name="system.phpunit.runtime" value="" spec="text description='PHPUnit runtime (if empty - latest PHPUnit.phar will be downloaded)' display='normal' label='PHPUnit runtime:' validationMode='any'" />
       <param name="system.phpunit.configuration" value="" spec="text description='PHPUnit configuration file' display='normal' label='PHPUnit configuration file:' validationMode='not_empty'" />
       <param name="system.php.workingDir.dir" value="" spec="text description='Working directory (if empty - current working directory will be used)' display='normal' label='Working directory:' validationMode='any'" />
+      <param name="system.php.executable.path" value="" spec="text description='Executable path (if empty - default path will be used)' display='normal' label='Executable path:' validationMode='any'" />
       <param name="system.phpunit.params" value="" spec="text description='Optional PHPUnit parameters' display='normal' label='PHPUnit parameters:' validationMode='any'" />
       <param name="system.phpunit.coverage.set" value="" spec="checkbox checkedValue='true' description='Enable if you want to enable PHPUnit code coverage reports' display='normal' label='Collect code coverage:' uncheckedValue='false'" />
     </parameters>
@@ -52,7 +53,7 @@
 </target>
 
 <target name="runPhpUnitPhar" depends="getPhpUnit" unless="phpunit.runtime.set">
-  <exec executable="php" dir="${php.workingDir}" failonerror="false" resultproperty="phpunit.result">
+  <exec executable="${php.executable.path}" dir="${php.workingDir}" failonerror="false" resultproperty="phpunit.result">
     <arg line="-f &quot;${phpunit.runtime.exec}&quot; -d display_errors=On -- -c &quot;${phpunit.configuration}&quot; --log-junit ${phpunit.junit.log} ${phpunit.coverage.param} ${phpunit.params}"/>
   </exec>  
 

--- a/php/MRPP_PHP_PHPUnit.xml
+++ b/php/MRPP_PHP_PHPUnit.xml
@@ -6,7 +6,7 @@
       <param name="system.phpunit.runtime" value="" spec="text description='PHPUnit runtime (if empty - latest PHPUnit.phar will be downloaded)' display='normal' label='PHPUnit runtime:' validationMode='any'" />
       <param name="system.phpunit.configuration" value="" spec="text description='PHPUnit configuration file' display='normal' label='PHPUnit configuration file:' validationMode='not_empty'" />
       <param name="system.php.workingDir.dir" value="" spec="text description='Working directory (if empty - current working directory will be used)' display='normal' label='Working directory:' validationMode='any'" />
-      <param name="system.php.executable.path" value="" spec="text description='Executable path (if empty - default path will be used)' display='normal' label='Executable path:' validationMode='any'" />
+      <param name="system.php.executable.path" value="php" spec="text description='PHP executable path (if empty - default path will be used)' display='normal' label='PHP executable path:' validationMode='any'" />
       <param name="system.phpunit.params" value="" spec="text description='Optional PHPUnit parameters' display='normal' label='PHPUnit parameters:' validationMode='any'" />
       <param name="system.phpunit.coverage.set" value="" spec="checkbox checkedValue='true' description='Enable if you want to enable PHPUnit code coverage reports' display='normal' label='Collect code coverage:' uncheckedValue='false'" />
     </parameters>


### PR DESCRIPTION
On a build server running multiple versions of PHP it may be desirable to be able to specify the PHP executable path.

In my case I need to test code in both php5.6 and php7 and not being able to specify the executable path is problematic since only the default php executable is used by default. Now I can configure the path from within TeamCity. Leaving the field empty will result in using the standard executable path which is `php`.