### PR TITLE
Added support for excluding assemblies within the DotCover MetaRunner

### DIFF
--- a/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
+++ b/xUnit.net-dotCover/MRPP_xunit_dotcover.xml
@@ -9,6 +9,7 @@
       <param name="xUnitNet.executable.args" value="" spec="text description='Custom xunit runner arguments' display='normal' label='Xunit Runner Executable additional arguments'" />
       <param name="xUnitNet.executable.legacymode" value="false" spec="checkbox checkedValue='true' description='For mixed mode assemblies, enables xunit runner to use legacy activiation' uncheckedValue='false' label='Enable .Net V2 Legacy Activation' display='normal'" />
       <param name="xUnitNet.assembliesPath" value="*/bin/*tests.dll" spec="text description='The assemblies to test; relative to the working directory. Supports multiple paths separated by comma(,) or newline. Asterix wildcard (*) is supported here' display='normal' label='Assemblies to test:'" />
+      <param name="xUnitNet.assembliesExcludePath" value="" spec="text description='The assemblies to exclude; Supports multiple filenames separated by comma(,) or newline. Asterix wildcard (*) is supported here' display='normal' label='Assemblies to exclude:'" />
       <param name="xUnitNet.trait" value="" spec="text description='only run tests with matching name/value traits, one name=value per line (e.x. name=value)' validationMode='any' label='Include Traits' display='normal'" />
       <param name="xUnitNet.notrait" value="Category=Integration" spec="text description='do not run tests with matching name/value traits, one name=value per line (e.x. name=value)' validationMode='any' label='Exclude Traits' display='normal'" />
       <param name="xUnitNet.dotCover.enable" value="true" spec="checkbox checkedValue='true' description='Enables or disables running test coverage with dotCover' uncheckedValue='false' label='Enable dotCover coverage' display='normal'" />
@@ -55,6 +56,7 @@ Param (
     [string] $dotCoverExecutable = "%teamcity.tool.dotCover%",
     [boolean] $xunitLegacy = [System.Convert]::ToBoolean("%xUnitNet.executable.legacymode%"),
     [string] $assemblyFilter = "%xUnitNet.assembliesPath%",
+    [string] $assemblyExcludeFilter = "%xUnitNet.assembliesExcludePath%",
     [string] $traits = "%xUnitNet.trait%",
     [string] $notraits = "%xUnitNet.notrait%",
     [boolean] $dotCoverEnabled = [System.Convert]::ToBoolean("%xUnitNet.dotCover.enable%"),
@@ -83,6 +85,17 @@ try {
 		$doc.Save($config)
   }
   
+  ## Process Assemblies to be Excluded
+  ## split string into array if multiple wildcard path separated by comma(,) or newline  
+  $assemblyExcludeFilterPaths = $assemblyExcludeFilter.Trim() -split {$_ -eq "," -or $_ -eq "`n" }
+  $excludedAssemblies = @()
+
+  foreach($filterExcludePath in $assemblyExcludeFilterPaths)
+  {
+    ## Concatenate each Assembly into the array
+    $excludedAssemblies +=,$filterExcludePath.Trim()
+  }
+  
   ##split string into array if multiple wildcard path separated by comma(,) or newline	
    $assemblyFilterPaths = $assemblyFilter.Trim() -split {$_ -eq "," -or $_ -eq "`n" }
    
@@ -90,8 +103,8 @@ try {
    
 	foreach($filterPath in $assemblyFilterPaths)
 	{
-    ## Search for the assemblies using wildcard pattern
-	$assembliesFromPath = (Get-ChildItem $filterPath.Trim() -Recurse | select -ExpandProperty FullName)
+    ## Search for the assemblies using wildcard pattern (Also filter out excluded assemblies)
+	$assembliesFromPath = (Get-ChildItem $filterPath.Trim() -Recurse -Exclude $excludedAssemblies.Trim() | select -ExpandProperty FullName)
 	$assemblies+= $assembliesFromPath
 	}
 	


### PR DESCRIPTION
This supports filenames with asterix(*).

e.g. A sample list of filenames/assemblies to exclude:


`*Apache.NMS*.dll`
`SomeSampleTestAssembly.dll`

This feature makes sure that it minimizes the race conditions within XUnit 2.0 + DotCover, due to a bug within DotNet Framework (https://github.com/dotnet/roslyn/issues/6358). Although this bug was recently fixed, this feature is Nice to Have so as to avoid processing unwanted assemblies.

The bug is solved in .Net Framework v4.6.2 (So race conditions would still arise on prior versions of DotNet and XUnit 2.0).