### PR TITLE
cleanup add-build-tags

### DIFF
--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -6,12 +6,10 @@
   <description />
   <settings>
     <parameters>
-      <param name="system.username" value="" spec="text description='Username of a user who performs action' display='normal' label='Username:' validationMode='not_empty'" />
-      <param name="system.password" value="" spec="password description='Password of a user who performs action' display='normal' label='Password:'" />
       <param name="system.tags" value="" spec="text description='Space separated tags for build' display='normal' label='Tags:' validationMode='not_empty'" />
     </parameters>
     <build-runners>
-      <runner id="RUNNER_12" name="" type="Ant">
+      <runner name="Add Build Tags" type="Ant">
         <parameters>
           <param name="build-file"><![CDATA[
                       
@@ -71,7 +69,7 @@
                   <headers>
                     <header name="Content-Type" value="application/xml" />
                   </headers>
-                  <credentials username="${username}" password="${password}" />
+                  <credentials username="${teamcity.auth.userId}" password="${teamcity.auth.password}" />
                   <entity file="${reqParams.file}" binary="false" />
                 </http>
               </target>

--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -6,6 +6,8 @@
   <description />
   <settings>
     <parameters>
+      <param name="system.username" value="" spec="text description='Username of a user who performs action' display='normal' label='Username:' validationMode='not_empty'" />
+      <param name="system.password" value="" spec="password description='Password of a user who performs action' display='normal' label='Password:'" />
       <param name="system.tags" value="" spec="text description='Space separated tags for build' display='normal' label='Tags:' validationMode='not_empty'" />
     </parameters>
     <build-runners>
@@ -67,7 +69,7 @@
                   <headers>
                     <header name="Content-Type" value="text/plain" />
                   </headers>
-                  <credentials username="${teamcity.auth.userId}" password="${teamcity.auth.password}" />
+                  <credentials username="${username}" password="${password}" />
                   <entity file="${reqParams.file}" binary="false" />
                 </http>
               </target>

--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -2,97 +2,97 @@
 <!DOCTYPE build-type SYSTEM "../../../project-config.dtd">
 
 <build-type>
-    <name>Add Build Tags</name>
-    <description />
-    <settings>
+  <name>Add Build Tags</name>
+  <description/>
+  <settings>
+    <parameters>
+      <param name="system.username" value="" spec="text description='Username of a user who performs action' display='normal' label='Username:' validationMode='not_empty'"/>
+      <param name="system.password" value="" spec="password description='Password of a user who performs action' display='normal' label='Password:'"/>
+      <param name="system.tags" value="" spec="text description='Space separated tags for build' display='normal' label='Tags:' validationMode='not_empty'"/>
+    </parameters>
+    <build-runners>
+      <runner id="RUNNER_12" name="" type="Ant">
         <parameters>
-            <param name="system.username" value="" spec="text description='Username of a user who performs action' display='normal' label='Username:' validationMode='not_empty'" />
-            <param name="system.password" value="" spec="password description='Password of a user who performs action' display='normal' label='Password:'" />
-            <param name="system.tags" value="" spec="text description='Space separated tags for build' display='normal' label='Tags:' validationMode='not_empty'" />
-        </parameters>
-        <build-runners>
-            <runner id="RUNNER_12" name="" type="Ant">
-                <parameters>
-                    <param name="build-file"><![CDATA[
-                    
-                        <project name="Add build tags">
-    
-                            <taskdef name="http" classname="org.missinglink.ant.task.http.HttpClientTask"/>
-    
-                            <property name="tags.file" location="${teamcity.build.tempDir}/tags.txt"/>
-                            <property name="reqParams.file" location="${teamcity.build.tempDir}/rawParams.txt"/>
-    
-                            <target name="prepare-params">
-    
-                                <echo file="${tags.file}">${tags}</echo>
-    
-                                <replaceregexp file="${tags.file}"
-                                match="&amp;amp;"
-                                replace="&amp;amp;amp;"
-                                flags="gm"
-                                />
-        
-                                <replaceregexp file="${tags.file}"
-                                match="&amp;lt;"
-                                replace="&amp;amp;lt;"
-                                flags="gm"
-                                />
-        
-                                <replaceregexp file="${tags.file}"
-                                match="^\s+"
-                                replace=""
-                                flags="gm"
-                                />
-        
-                                <replaceregexp file="${tags.file}"
-                                match="\s+$"
-                                replace=""
-                                flags="gm"
-                                />
-        
-                                <replaceregexp file="${tags.file}"
-                                match="(\s+)"
-                                replace="&amp;lt;/tag&gt;&amp;lt;tag&gt;"
-                                flags="gm"
-                                />
-    
-    
-                                <loadfile srcFile="${tags.file}" property="prepared.tags"/>
-    
-                                <echo file="${reqParams.file}">&lt;tags&gt;&lt;tag&gt;${prepared.tags}&lt;/tag&gt;&lt;/tags&gt;</echo>
-    
-                            </target>
-    
-                            <target name="addTags" depends="prepare-params">
-                                <http url="%teamcity.serverUrl%/httpAuth/app/rest/8.0/builds/id:%teamcity.build.id%/tags"
-                                method="POST"
-                                expected="204"
-                                printrequest="true">
-                                    <headers>
-                                        <header name="Content-Type" value="application/xml"/>
-                                    </headers>
-                                    <credentials username="${username}" password="${password}"/>
-                                    <entity file="${reqParams.file}" binary="false"/>
-                                </http>
-                            </target>
+          <param name="build-file"><![CDATA[
+                      
+            <project name="Add build tags">
+  
+              <taskdef name="http" classname="org.missinglink.ant.task.http.HttpClientTask"/>
 
-                        </project>
-                    ]]></param>
-                    <param name="build-file-path" value="build.xml" />
-                    <param name="target" value="addTags" />
-                    <param name="runnerArgs" value="-lib %teamcity.tool.ant-net-tasks%" />
-                    <param name="teamcity.coverage.emma.include.source" value="true" />
-                    <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*" />
-                    <param name="teamcity.coverage.idea.includePatterns" value="*" />
-                    <param name="teamcity.step.mode" value="default" />
-                    <param name="use-custom-build-file" value="true" />
-                </parameters>
-            </runner>
-        </build-runners>
-        <vcs-settings checkout-mode="ON_SERVER" labeling-type="NONE" labeling-pattern="build-%system.build.number%" />
-        <requirements />
-        <build-triggers />
-        <cleanup />
-    </settings>
+              <property name="tags.file" location="${teamcity.build.tempDir}/tags.txt"/>
+              <property name="reqParams.file" location="${teamcity.build.tempDir}/rawParams.txt"/>
+
+              <target name="prepare-params">
+
+                <echo file="${tags.file}">${tags}</echo>
+
+                <replaceregexp file="${tags.file}"
+                match="&amp;amp;"
+                replace="&amp;amp;amp;"
+                flags="gm"
+                />
+
+                <replaceregexp file="${tags.file}"
+                match="&amp;lt;"
+                replace="&amp;amp;lt;"
+                flags="gm"
+                />
+
+                <replaceregexp file="${tags.file}"
+                match="^\s+"
+                replace=""
+                flags="gm"
+                />
+
+                <replaceregexp file="${tags.file}"
+                match="\s+$"
+                replace=""
+                flags="gm"
+                />
+
+                <replaceregexp file="${tags.file}"
+                match="(\s+)"
+                replace="&amp;lt;/tag&gt;&amp;lt;tag&gt;"
+                flags="gm"
+                />
+
+
+                <loadfile srcFile="${tags.file}" property="prepared.tags"/>
+
+                <echo file="${reqParams.file}">&lt;tags&gt;&lt;tag&gt;${prepared.tags}&lt;/tag&gt;&lt;/tags&gt;</echo>
+
+              </target>
+
+              <target name="addTags" depends="prepare-params">
+                <http url="%teamcity.serverUrl%/httpAuth/app/rest/8.0/builds/id:%teamcity.build.id%/tags"
+                method="POST"
+                expected="204"
+                printrequest="true">
+                  <headers>
+                    <header name="Content-Type" value="application/xml"/>
+                  </headers>
+                  <credentials username="${username}" password="${password}"/>
+                  <entity file="${reqParams.file}" binary="false"/>
+                </http>
+              </target>
+
+            </project>
+          ]]></param>
+          <param name="build-file-path" value="build.xml"/>
+          <param name="target" value="addTags"/>
+          <param name="runnerArgs" value="-lib %teamcity.tool.ant-net-tasks%"/>
+          <param name="teamcity.coverage.emma.include.source" value="true"/>
+          <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*"/>
+          <param name="teamcity.coverage.idea.includePatterns" value="*"/>
+          <param name="teamcity.step.mode" value="default"/>
+          <param name="use-custom-build-file" value="true"/>
+        </parameters>
+      </runner>
+    </build-runners>
+    <vcs-settings checkout-mode="ON_SERVER" labeling-type="NONE" labeling-pattern="build-%system.build.number%"/>
+    <requirements/>
+    <build-triggers/>
+    <cleanup/>
+  </settings>
 </build-type>
 

--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE build-type SYSTEM "../../../project-config.dtd">
+
 <build-type>
     <name>Add Build Tags</name>
     <description />

--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -1,94 +1,96 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE build-type SYSTEM "../../../project-config.dtd">
-
 <build-type>
-  <name>Add Build Tags</name>
-  <description />
-  <settings>
-    <parameters>
-      <param name="system.username" value="" spec="text description='Username of a user who performs action' display='normal' label='Username:' validationMode='not_empty'" />
-      <param name="system.password" value="" spec="password description='Password of a user who performs action' display='normal' label='Password:'" />
-      <param name="system.tags" value="" spec="text description='Space separated tags for build' display='normal' label='Tags:' validationMode='not_empty'" />
-    </parameters>
-    <build-runners>
-      <runner id="RUNNER_12" name="" type="Ant">
+    <name>Add Build Tags</name>
+    <description />
+    <settings>
         <parameters>
-          <param name="build-file">&lt;project name="Add build tags"&gt;
-
-&lt;taskdef name="http" classname="org.missinglink.ant.task.http.HttpClientTask"/&gt;
-
-&lt;property name="tags.file" location="${teamcity.build.tempDir}/tags.txt"/&gt;
-&lt;property name="reqParams.file" location="${teamcity.build.tempDir}/rawParams.txt"/&gt;
-
-&lt;target name="prepare-params"&gt;
-
-&lt;echo file="${tags.file}"&gt;${tags}&lt;/echo&gt;
-&lt;replaceregexp file="${tags.file}"
-               match="&amp;amp;"
-               replace="&amp;amp;amp;"
-               flags="gm"
-/&gt;
-
-&lt;replaceregexp file="${tags.file}"
-               match="&amp;lt;"
-               replace="&amp;amp;lt;"
-               flags="gm"
-/&gt;
-
-&lt;replaceregexp file="${tags.file}"
-               match="^\s+"
-               replace=""
-               flags="gm"
-/&gt;
-
-&lt;replaceregexp file="${tags.file}"
-               match="\s+$"
-               replace=""
-               flags="gm"
-/&gt;
-
-&lt;replaceregexp file="${tags.file}"
-               match="(\s+)"
-               replace="&amp;lt;/tag&gt;&amp;lt;tag&gt;"
-               flags="gm"
-/&gt;
-
-
-&lt;loadfile srcFile="${tags.file}" property="prepared.tags"/&gt;
-
-&lt;echo file="${reqParams.file}"&gt;&lt;![CDATA[&lt;tags&gt;&lt;tag&gt;${prepared.tags}&lt;/tag&gt;&lt;/tags&gt;]]&gt;&lt;/echo&gt;
-
-&lt;/target&gt;
-
-&lt;target name="addTags" depends="prepare-params"&gt;
-&lt;http url="%teamcity.serverUrl%/httpAuth/app/rest/8.0/builds/id:%teamcity.build.id%/tags" 
-      method="POST" 
-      expected="204"
-      printrequest="true"&gt;
-&lt;headers&gt;
-&lt;header name="Content-Type" value="application/xml"/&gt;
-&lt;/headers&gt;
-&lt;credentials username="${username}" password="${password}"/&gt;
-&lt;entity file="${reqParams.file}" binary="false"/&gt;
-&lt;/http&gt;
-&lt;/target&gt;
-
-&lt;/project&gt;</param>
-          <param name="build-file-path" value="build.xml" />
-          <param name="target" value="addTags" />
-          <param name="runnerArgs" value="-lib %teamcity.tool.ant-net-tasks%" />
-          <param name="teamcity.coverage.emma.include.source" value="true" />
-          <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*" />
-          <param name="teamcity.coverage.idea.includePatterns" value="*" />
-          <param name="teamcity.step.mode" value="default" />
-          <param name="use-custom-build-file" value="true" />
+            <param name="system.username" value="" spec="text description='Username of a user who performs action' display='normal' label='Username:' validationMode='not_empty'" />
+            <param name="system.password" value="" spec="password description='Password of a user who performs action' display='normal' label='Password:'" />
+            <param name="system.tags" value="" spec="text description='Space separated tags for build' display='normal' label='Tags:' validationMode='not_empty'" />
         </parameters>
-      </runner>
-    </build-runners>
-    <vcs-settings checkout-mode="ON_SERVER" labeling-type="NONE" labeling-pattern="build-%system.build.number%" />
-    <requirements />
-    <build-triggers />
-    <cleanup />
-  </settings>
+        <build-runners>
+            <runner id="RUNNER_12" name="" type="Ant">
+                <parameters>
+                    <param name="build-file"><![CDATA[
+                    
+                        <project name="Add build tags">
+    
+                            <taskdef name="http" classname="org.missinglink.ant.task.http.HttpClientTask"/>
+    
+                            <property name="tags.file" location="${teamcity.build.tempDir}/tags.txt"/>
+                            <property name="reqParams.file" location="${teamcity.build.tempDir}/rawParams.txt"/>
+    
+                            <target name="prepare-params">
+    
+                                <echo file="${tags.file}">${tags}</echo>
+    
+                                <replaceregexp file="${tags.file}"
+                                match="&amp;amp;"
+                                replace="&amp;amp;amp;"
+                                flags="gm"
+                                />
+        
+                                <replaceregexp file="${tags.file}"
+                                match="&amp;lt;"
+                                replace="&amp;amp;lt;"
+                                flags="gm"
+                                />
+        
+                                <replaceregexp file="${tags.file}"
+                                match="^\s+"
+                                replace=""
+                                flags="gm"
+                                />
+        
+                                <replaceregexp file="${tags.file}"
+                                match="\s+$"
+                                replace=""
+                                flags="gm"
+                                />
+        
+                                <replaceregexp file="${tags.file}"
+                                match="(\s+)"
+                                replace="&amp;lt;/tag&gt;&amp;lt;tag&gt;"
+                                flags="gm"
+                                />
+    
+    
+                                <loadfile srcFile="${tags.file}" property="prepared.tags"/>
+    
+                                <echo file="${reqParams.file}">&lt;tags&gt;&lt;tag&gt;${prepared.tags}&lt;/tag&gt;&lt;/tags&gt;</echo>
+    
+                            </target>
+    
+                            <target name="addTags" depends="prepare-params">
+                                <http url="%teamcity.serverUrl%/httpAuth/app/rest/8.0/builds/id:%teamcity.build.id%/tags"
+                                method="POST"
+                                expected="204"
+                                printrequest="true">
+                                    <headers>
+                                        <header name="Content-Type" value="application/xml"/>
+                                    </headers>
+                                    <credentials username="${username}" password="${password}"/>
+                                    <entity file="${reqParams.file}" binary="false"/>
+                                </http>
+                            </target>
+
+                        </project>
+                    ]]></param>
+                    <param name="build-file-path" value="build.xml" />
+                    <param name="target" value="addTags" />
+                    <param name="runnerArgs" value="-lib %teamcity.tool.ant-net-tasks%" />
+                    <param name="teamcity.coverage.emma.include.source" value="true" />
+                    <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*" />
+                    <param name="teamcity.coverage.idea.includePatterns" value="*" />
+                    <param name="teamcity.step.mode" value="default" />
+                    <param name="use-custom-build-file" value="true" />
+                </parameters>
+            </runner>
+        </build-runners>
+        <vcs-settings checkout-mode="ON_SERVER" labeling-type="NONE" labeling-pattern="build-%system.build.number%" />
+        <requirements />
+        <build-triggers />
+        <cleanup />
+    </settings>
 </build-type>
 

--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -3,12 +3,12 @@
 
 <build-type>
   <name>Add Build Tags</name>
-  <description/>
+  <description />
   <settings>
     <parameters>
-      <param name="system.username" value="" spec="text description='Username of a user who performs action' display='normal' label='Username:' validationMode='not_empty'"/>
-      <param name="system.password" value="" spec="password description='Password of a user who performs action' display='normal' label='Password:'"/>
-      <param name="system.tags" value="" spec="text description='Space separated tags for build' display='normal' label='Tags:' validationMode='not_empty'"/>
+      <param name="system.username" value="" spec="text description='Username of a user who performs action' display='normal' label='Username:' validationMode='not_empty'" />
+      <param name="system.password" value="" spec="password description='Password of a user who performs action' display='normal' label='Password:'" />
+      <param name="system.tags" value="" spec="text description='Space separated tags for build' display='normal' label='Tags:' validationMode='not_empty'" />
     </parameters>
     <build-runners>
       <runner id="RUNNER_12" name="" type="Ant">
@@ -17,47 +17,47 @@
                       
             <project name="Add build tags">
   
-              <taskdef name="http" classname="org.missinglink.ant.task.http.HttpClientTask"/>
+              <taskdef name="http" classname="org.missinglink.ant.task.http.HttpClientTask" />
 
-              <property name="tags.file" location="${teamcity.build.tempDir}/tags.txt"/>
-              <property name="reqParams.file" location="${teamcity.build.tempDir}/rawParams.txt"/>
+              <property name="tags.file" location="${teamcity.build.tempDir}/tags.txt" />
+              <property name="reqParams.file" location="${teamcity.build.tempDir}/rawParams.txt" />
 
               <target name="prepare-params">
 
                 <echo file="${tags.file}">${tags}</echo>
 
                 <replaceregexp file="${tags.file}"
-                match="&amp;amp;"
-                replace="&amp;amp;amp;"
-                flags="gm"
+                            match="&amp;amp;"
+                            replace="&amp;amp;amp;"
+                            flags="gm"
                 />
 
                 <replaceregexp file="${tags.file}"
-                match="&amp;lt;"
-                replace="&amp;amp;lt;"
-                flags="gm"
+                            match="&amp;lt;"
+                            replace="&amp;amp;lt;"
+                            flags="gm"
                 />
 
                 <replaceregexp file="${tags.file}"
-                match="^\s+"
-                replace=""
-                flags="gm"
+                            match="^\s+"
+                            replace=""
+                            flags="gm"
                 />
 
                 <replaceregexp file="${tags.file}"
-                match="\s+$"
-                replace=""
-                flags="gm"
+                            match="\s+$"
+                            replace=""
+                            flags="gm"
                 />
 
                 <replaceregexp file="${tags.file}"
-                match="(\s+)"
-                replace="&amp;lt;/tag&gt;&amp;lt;tag&gt;"
-                flags="gm"
+                            match="(\s+)"
+                            replace="&amp;lt;/tag&gt;&amp;lt;tag&gt;"
+                            flags="gm"
                 />
 
 
-                <loadfile srcFile="${tags.file}" property="prepared.tags"/>
+                <loadfile srcFile="${tags.file}" property="prepared.tags" />
 
                 <echo file="${reqParams.file}">&lt;tags&gt;&lt;tag&gt;${prepared.tags}&lt;/tag&gt;&lt;/tags&gt;</echo>
 
@@ -69,30 +69,30 @@
                 expected="204"
                 printrequest="true">
                   <headers>
-                    <header name="Content-Type" value="application/xml"/>
+                    <header name="Content-Type" value="application/xml" />
                   </headers>
-                  <credentials username="${username}" password="${password}"/>
-                  <entity file="${reqParams.file}" binary="false"/>
+                  <credentials username="${username}" password="${password}" />
+                  <entity file="${reqParams.file}" binary="false" />
                 </http>
               </target>
 
             </project>
           ]]></param>
-          <param name="build-file-path" value="build.xml"/>
-          <param name="target" value="addTags"/>
-          <param name="runnerArgs" value="-lib %teamcity.tool.ant-net-tasks%"/>
-          <param name="teamcity.coverage.emma.include.source" value="true"/>
-          <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*"/>
-          <param name="teamcity.coverage.idea.includePatterns" value="*"/>
-          <param name="teamcity.step.mode" value="default"/>
-          <param name="use-custom-build-file" value="true"/>
+          <param name="build-file-path" value="build.xml" />
+          <param name="target" value="addTags" />
+          <param name="runnerArgs" value="-lib %teamcity.tool.ant-net-tasks%" />
+          <param name="teamcity.coverage.emma.include.source" value="true" />
+          <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*" />
+          <param name="teamcity.coverage.idea.includePatterns" value="*" />
+          <param name="teamcity.step.mode" value="default" />
+          <param name="use-custom-build-file" value="true" />
         </parameters>
       </runner>
     </build-runners>
-    <vcs-settings checkout-mode="ON_SERVER" labeling-type="NONE" labeling-pattern="build-%system.build.number%"/>
-    <requirements/>
-    <build-triggers/>
-    <cleanup/>
+    <vcs-settings checkout-mode="ON_SERVER" labeling-type="NONE" labeling-pattern="build-%system.build.number%" />
+    <requirements />
+    <build-triggers />
+    <cleanup />
   </settings>
 </build-type>
 

--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE build-type SYSTEM "../../../project-config.dtd">
-
 <build-type>
   <name>Add Build Tags</name>
   <description />
@@ -11,9 +9,7 @@
     <build-runners>
       <runner name="Add Build Tags" type="Ant">
         <parameters>
-          <param name="build-file"><![CDATA[
-                      
-            <project name="Add build tags">
+          <param name="build-file"><![CDATA[<project name="Add build tags">
   
               <taskdef name="http" classname="org.missinglink.ant.task.http.HttpClientTask" />
 
@@ -57,25 +53,24 @@
 
                 <loadfile srcFile="${tags.file}" property="prepared.tags" />
 
-                <echo file="${reqParams.file}">&lt;tags&gt;&lt;tag&gt;${prepared.tags}&lt;/tag&gt;&lt;/tags&gt;</echo>
+                <echo file="${reqParams.file}">${prepared.tags}</echo>
 
               </target>
 
               <target name="addTags" depends="prepare-params">
                 <http url="%teamcity.serverUrl%/httpAuth/app/rest/8.0/builds/id:%teamcity.build.id%/tags"
                 method="POST"
-                expected="204"
+                expected="200"
                 printrequest="true">
                   <headers>
-                    <header name="Content-Type" value="application/xml" />
+                    <header name="Content-Type" value="text/plain" />
                   </headers>
                   <credentials username="${teamcity.auth.userId}" password="${teamcity.auth.password}" />
                   <entity file="${reqParams.file}" binary="false" />
                 </http>
               </target>
 
-            </project>
-          ]]></param>
+            </project>]]></param>
           <param name="build-file-path" value="build.xml" />
           <param name="target" value="addTags" />
           <param name="runnerArgs" value="-lib %teamcity.tool.ant-net-tasks%" />

--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE build-type SYSTEM "../../../project-config.dtd">
+
 <build-type>
   <name>Add Build Tags</name>
   <description />


### PR DESCRIPTION
- make the contents of the build-file param a cdata section, and replace escaped entities with their corresponding characters, for ease of maintenance and better readability.

- send plain text instead of xml to teamcity server (and expect 200 status instead of 204).
