### PR TITLE
Fix TeamCity's Default Nuget Path

### DIFF
--- a/nuget/MRPP_NuGet_Install.xml
+++ b/nuget/MRPP_NuGet_Install.xml
@@ -44,7 +44,7 @@ function Build-Arguments {
   return $parameters
 }
 
-$nuget = Join-Path -Path '%teamcity.tool.NuGet.CommandLine.DEFAULT.nupkg%' -ChildPath 'tools\NuGet.exe'
+$nuget = Join-Path -Path '%teamcity.tool.NuGet.CommandLine.DEFAULT%' -ChildPath 'tools\NuGet.exe'
 $arguments = Build-Arguments
 
 if(%mr.NuGetInstall.Log%) {


### PR DESCRIPTION
%teamcity.tool.NuGet.CommandLine.DEFAULT.nupkg% is not valid anymore, you should use %teamcity.tool.NuGet.CommandLine.DEFAULT% instead.