### PR TITLE
Update PHPUnit download url to https

### DIFF
--- a/php/MRPP_PHP_PHPUnit.xml
+++ b/php/MRPP_PHP_PHPUnit.xml
@@ -79,7 +79,7 @@
 </target>
 
 <target name="getPhpUnit" unless="phpunit.runtime.set">
-  <get src="http://phar.phpunit.de/phpunit.phar" dest="${teamcity.build.tempDir}" verbose="on" skipexisting="false"/>
+  <get src="https://phar.phpunit.de/phpunit.phar" dest="${teamcity.build.tempDir}" verbose="on" skipexisting="false"/>
 </target>
 
 </project>]]></param>


### PR DESCRIPTION
download url of PHPUnit send a permanent redirect to https and Teamcity considers it unsafe.
"Redirection detected from http to https. Protocol switch unsafe, not allowed."
So, http was changed to https.