### PR TITLE
Added gitversion4 (beta) support as well as MR which sets TeamCity build counter as build number

### DIFF
--- a/gitversion/MR_GitVersion4-WithBuildCounter.xml
+++ b/gitversion/MR_GitVersion4-WithBuildCounter.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<meta-runner name="GitVersion4WithBuildCounter">
+  <description>Execute GitVersion 4 - Do not update build.number parameter</description>
+  <settings>
+    <parameters>
+      <param name="mr.GitVersion.gitCheckoutDir" value="" spec="text description='The directory containing .git relative to the working directory. Leave blank for the working directory itself.' display='normal' label='Git Repository Directory:'" />
+      <param name="mr.GitVersion.output" value="buildserver" spec="checkbox checkedValue='buildserver' description='Update Teamcity parameters or output JSON?' display='normal' label='Update Teamcity parameters:' uncheckedValue='json'" />
+      <param name="mr.GitVersion.outputFile" value="" spec="text description='Optional path to a file relative to the working directory to output the json into if you selected JSON above.' display='normal' label='Json output file:'" />
+      <param name="mr.GitVersion.url" value="" spec="text description='Optional URL to remote git repository if you have not already checked one out.' display='normal' label='Remote Git Repository:'" />
+      <param name="mr.GitVersion.dynamicRepoLocation" value="" spec="text description='Path to the dynamic repository GitVersion may have to create.' display='normal' label='Dynamic Repository Path:'" />
+      <param name="mr.GitVersion.branch" value="" spec="text description='Remote branch to use.' display='normal' label='Remote Git Branch:'" />
+      <param name="mr.GitVersion.commitId" value="" spec="text description='Commit to use. By default, the latest commit in the branch is used.' display='normal' label='Git Commit Hash:'" />
+      <param name="mr.GitVersion.username" value="" spec="text description='Remote git repo username (if private).' display='normal' label='Remote Git Username:'" />
+      <param name="mr.GitVersion.password" value="" spec="password description='Remote git repo password (if private).' display='normal' label='Remote Git Password:'" />
+      <param name="mr.GitVersion.logFile" value="" spec="text description='Optional path to a file relative to the working directory to log output messages to.' display='normal' label='Log File:'" />
+      <param name="mr.GitVersion.exec" value="" spec="text description='Optional executable relative to the working directory to run using GitVersion - environment vars will be available to the process.' display='normal' label='Executable:'" />
+      <param name="mr.GitVersion.execArgs" value="" spec="text description='If an Executable is specified then arguments to pass to the executable.' display='normal' label='Executable Arguments:'" />
+      <param name="mr.GitVersion.proj" value="" spec="text description='Optional MSBuild file relative to the working directory to run using GitVersion - environment vars will be available to the process.' display='normal' label='MSBuild File:'" />
+      <param name="mr.GitVersion.projArgs" value="" spec="text description='If an MSBuild file is specified then arguments to pass to MSBuild.' display='normal' label='MSBuild Arguments:'" />
+      <param name="mr.GitVersion.updateAssemblyInfo" value="false" spec="checkbox checkedValue='true' description='Update any AssemblyInfo files while running the Executable or MSBuild file?' display='normal' label='Update AssemblyInfo Files:' uncheckedValue='false'" />
+      <param name="mr.GitVersion.updateAssemblyInfoFileName" value="" spec="text description='If Update AssemblyInfo Files is specified then name of AssemblyInfo file to update.' display='normal' label='Update AssemblyInfo File Name:'" />
+      <param name="mr.GitVersion.updateGitVersion" value="false" spec="checkbox checkedValue='true' description='Use Chocolatey to check whether a new version of GitVersion is available?' display='normal' label='Update GitVersion:' uncheckedValue='false'" />
+    </parameters>
+    <build-runners>
+      <runner name="GitVersion" type="jetbrains_powershell">
+        <parameters>
+          <param name="jetbrains_powershell_execution" value="PS1" />
+          <param name="jetbrains_powershell_noprofile" value="true" />
+          <param name="jetbrains_powershell_errorToError" value="error" />
+          <param name="jetbrains_powershell_script_mode" value="CODE" />
+          <param name="jetbrains_powershell_bitness" value="x86" />
+          <param name="teamcity.step.mode" value="default" />
+          <param name="jetbrains_powershell_script_code"><![CDATA[
+[CmdletBinding()]
+Param (
+    [string] $workingDir = (Join-Path "%teamcity.build.workingDir%" "%mr.GitVersion.gitCheckoutDir%"),
+    [string] $output = '%mr.GitVersion.output%',
+    [string] $outputFile = '%mr.GitVersion.outputFile%',
+    [string] $url = '%mr.GitVersion.url%',
+    [string] $dynamicRepoLocation = '%mr.GitVersion.dynamicRepoLocation%',
+    [string] $branch = '%mr.GitVersion.branch%',
+    [string] $commitId = '%mr.GitVersion.commitId%',
+    [string] $username = '%mr.GitVersion.username%',
+    [string] $password = '%mr.GitVersion.password%',
+    [string] $logFile = '%mr.GitVersion.logFile%',
+    [string] $exec = '%mr.GitVersion.exec%',
+    [string] $execArgs = '%mr.GitVersion.execArgs%',
+    [string] $proj = '%mr.GitVersion.proj%',
+    [string] $projArgs = '%mr.GitVersion.projArgs%',
+    [string] $updateAssemblyInfo = '%mr.GitVersion.updateAssemblyInfo%',
+    [string] $updateAssemblyInfoFileName = '%mr.GitVersion.updateAssemblyInfoFileName%',
+    [string] $updateGitVersion = '%mr.GitVersion.updateGitVersion%'
+)
+
+$ErrorActionPreference = "Stop"
+
+function Join-ToWorkingDirectoryIfSpecified($path) {
+    $workingDir = "%teamcity.build.workingDir%"
+    if ($workingDir -match "teamcity.build.workingDir") {
+        return $path
+    }
+    if (Test-IsSpecified $path) {
+        return Join-Path $workingDir $path
+    }
+    return $path
+}
+
+function Test-IsSpecified ($value) {
+    if ($value -ne $null -and $value -ne "" -and -not ($value -match "mr.GitVersion.")) {
+        return $true
+    }
+    return $false
+}
+
+function Append-IfSpecified($appendTo, $command, $value) {
+    if (Test-IsSpecified $value) {
+        return "$appendTo /$command '$value'"
+    }
+    return $appendTo
+}
+
+function Build-Arguments() {
+    $args = "";
+    if (Test-IsSpecified $workingDir) {
+        $workingDir = $workingDir.TrimEnd('\')
+        $args = """$workingDir"""
+    }
+    $args = Append-IfSpecified $args "url" $url
+    $args = Append-IfSpecified $args "dynamicRepoLocation" $dynamicRepoLocation
+    $args = Append-IfSpecified $args "b" $branch
+    $args = Append-IfSpecified $args "c" $commitId
+    $args = Append-IfSpecified $args "u" $username
+    $args = Append-IfSpecified $args "p" $password
+    $args = Append-IfSpecified $args "l" $logFile
+    if (Test-IsSpecified $exec) {
+        $args = Append-IfSpecified $args "exec" $exec
+        $args = Append-IfSpecified $args "execargs" $execargs
+    }
+    if (Test-IsSpecified $proj) {
+        $args = Append-IfSpecified $args "proj" $proj
+        $args = Append-IfSpecified $args "projargs" $projargs
+    }
+    if ($updateAssemblyInfo -eq "true") {
+        if (Test-IsSpecified $updateAssemblyInfoFileName) {
+            $args = "$args /UpdateAssemblyInfo $updateAssemblyInfoFileName"
+        } else {
+            $args = "$args /UpdateAssemblyInfo"
+        }
+    }
+    if ($output -eq "json" -and (Test-IsSpecified $outputFile)) {
+        $args = "$args > ""$outputFile"""
+    }
+    return $args
+}
+
+try {
+
+    $chocolateyDir = $null
+    if ($env:ChocolateyInstall -ne $null) {
+        $chocolateyDir = $env:ChocolateyInstall
+    } elseif (Test-Path (Join-Path $env:SYSTEMDRIVE Chocolatey)) {
+        $chocolateyDir = Join-Path $env:SYSTEMDRIVE Chocolatey
+    } elseif (Test-Path (Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey)) {
+        $chocolateyDir = Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey
+    }
+
+    if ($chocolateyDir -eq $null) {
+        Write-Host "##teamcity[progressMessage 'Chocolatey not installed; installing Chocolatey']"
+        & { iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')) }
+        $chocolateyDir = Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey
+        if (-not (Test-Path $chocolateyDir)) {
+            throw "Error installing Chocolatey"
+        }
+    } else {
+        Write-Host "Chocolatey already installed"
+    }
+
+    $chocolateyBinDir = Join-Path $chocolateyDir "bin"
+    $gitversion = Join-Path $chocolateyBinDir "gitversion.bat"
+    if (-not (Test-Path $gitversion)) {
+        $gitversion = Join-Path $chocolateyBinDir "gitversion.exe"
+    }
+
+    $choco = Join-Path $chocolateyDir "choco.exe"
+
+    if (-not (Test-Path $gitversion)) {
+        Write-Host "##teamcity[progressMessage 'GitVersion not installed; installing GitVersion']"
+        iex "$choco install gitversion.portable -y --pre"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Error installing GitVersion"
+        }
+    } else {
+        Write-Host "GitVersion already installed"
+    }
+
+    if ($updateGitVersion -eq "true") {
+        Write-Host "##teamcity[progressMessage 'Checking for updated version of GitVersion']"
+        iex "$choco upgrade gitversion.portable -y --pre"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Error updating GitVersion"
+        }
+    } else {
+        Write-Host "GitVersion will not be updated"
+    }
+
+    $outputFile = Join-ToWorkingDirectoryIfSpecified $outputFile
+    $logFile = Join-ToWorkingDirectoryIfSpecified $logFile
+    $exec = Join-ToWorkingDirectoryIfSpecified $exec
+    $proj = Join-ToWorkingDirectoryIfSpecified $proj
+
+    $arguments = Build-Arguments
+
+    $safeArgs = $arguments.Replace("'", """")
+
+    if($password) {
+      $safeArgs = $arguments.Replace($password, "*****")
+    }
+
+    Write-Host "##teamcity[progressMessage 'Running: $gitversion $safeArgs']"
+    $gvOutput = Invoke-Expression "gitversion $arguments" | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        throw "Error running GitVersion"
+    }
+    if ($output -eq "json") {
+        Write-Host $gvOutput
+    } else {
+       $json = ConvertFrom-Json $gvOutput
+       $json.PSObject.Properties | ForEach-Object {
+          $name = $_.Name
+          $val = $_.Value
+          Write-Host "##teamcity[setParameter name='GitVersion.$name' value='$val']"
+          Write-Host "##teamcity[setParameter name='system.GitVersion.$name' value='$val']"
+       }
+       $semVer = $json.SemVer
+       Write-Host "##teamcity[buildNumber '$semVer+build%build.counter%']"
+    }
+}
+catch {
+    Write-Host "##teamcity[buildStatus text='$_' status='FAILURE']"
+    Write-Host "##teamcity[message text='$_' status='ERROR']"
+    exit 1
+}
+          ]]></param>
+        </parameters>
+      </runner>
+    </build-runners>
+    <requirements />
+  </settings>
+</meta-runner>

--- a/gitversion/MR_GitVersion4.xml
+++ b/gitversion/MR_GitVersion4.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<meta-runner name="GitVersion4">
+  <description>Execute GitVersion 4</description>
+  <settings>
+    <parameters>
+      <param name="mr.GitVersion.gitCheckoutDir" value="" spec="text description='The directory containing .git relative to the working directory. Leave blank for the working directory itself.' display='normal' label='Git Repository Directory:'" />
+      <param name="mr.GitVersion.output" value="buildserver" spec="checkbox checkedValue='buildserver' description='Update the TeamCity build number or output JSON?' display='normal' label='Update TeamCity build version:' uncheckedValue='json'" />
+      <param name="mr.GitVersion.outputFile" value="" spec="text description='Optional path to a file relative to the working directory to output the json into if you selected JSON above.' display='normal' label='Json output file:'" />
+      <param name="mr.GitVersion.url" value="" spec="text description='Optional URL to remote git repository if you have not already checked one out.' display='normal' label='Remote Git Repository:'" />
+      <param name="mr.GitVersion.dynamicRepoLocation" value="" spec="text description='Path to the dynamic repository GitVersion may have to create.' display='normal' label='Dynamic Repository Path:'" />
+      <param name="mr.GitVersion.branch" value="" spec="text description='Remote branch to use.' display='normal' label='Remote Git Branch:'" />
+      <param name="mr.GitVersion.commitId" value="" spec="text description='Commit to use. By default, the latest commit in the branch is used.' display='normal' label='Git Commit Hash:'" />
+      <param name="mr.GitVersion.username" value="" spec="text description='Remote git repo username (if private).' display='normal' label='Remote Git Username:'" />
+      <param name="mr.GitVersion.password" value="" spec="password description='Remote git repo password (if private).' display='normal' label='Remote Git Password:'" />
+      <param name="mr.GitVersion.logFile" value="" spec="text description='Optional path to a file relative to the working directory to log output messages to.' display='normal' label='Log File:'" />
+      <param name="mr.GitVersion.exec" value="" spec="text description='Optional executable relative to the working directory to run using GitVersion - environment vars will be available to the process.' display='normal' label='Executable:'" />
+      <param name="mr.GitVersion.execArgs" value="" spec="text description='If an Executable is specified then arguments to pass to the executable.' display='normal' label='Executable Arguments:'" />
+      <param name="mr.GitVersion.proj" value="" spec="text description='Optional MSBuild file relative to the working directory to run using GitVersion - environment vars will be available to the process.' display='normal' label='MSBuild File:'" />
+      <param name="mr.GitVersion.projArgs" value="" spec="text description='If an MSBuild file is specified then arguments to pass to MSBuild.' display='normal' label='MSBuild Arguments:'" />
+      <param name="mr.GitVersion.updateAssemblyInfo" value="false" spec="checkbox checkedValue='true' description='Update any AssemblyInfo files while running the Executable or MSBuild file?' display='normal' label='Update AssemblyInfo Files:' uncheckedValue='false'" />
+      <param name="mr.GitVersion.updateAssemblyInfoFileName" value="" spec="text description='If Update AssemblyInfo Files is specified then name of AssemblyInfo file to update.' display='normal' label='Update AssemblyInfo File Name:'" />
+      <param name="mr.GitVersion.updateGitVersion" value="false" spec="checkbox checkedValue='true' description='Use Chocolatey to check whether a new version of GitVersion is available?' display='normal' label='Update GitVersion:' uncheckedValue='false'" />
+    </parameters>
+    <build-runners>
+      <runner name="GitVersion" type="jetbrains_powershell">
+        <parameters>
+          <param name="jetbrains_powershell_execution" value="PS1" />
+          <param name="jetbrains_powershell_noprofile" value="true" />
+          <param name="jetbrains_powershell_errorToError" value="error" />
+          <param name="jetbrains_powershell_script_mode" value="CODE" />
+          <param name="jetbrains_powershell_bitness" value="x86" />
+          <param name="teamcity.step.mode" value="default" />
+          <param name="jetbrains_powershell_script_code"><![CDATA[
+[CmdletBinding()]
+Param (
+    [string] $workingDir = (Join-Path "%teamcity.build.workingDir%" "%mr.GitVersion.gitCheckoutDir%"),
+    [string] $output = '%mr.GitVersion.output%',
+    [string] $outputFile = '%mr.GitVersion.outputFile%',
+    [string] $url = '%mr.GitVersion.url%',
+    [string] $dynamicRepoLocation = '%mr.GitVersion.dynamicRepoLocation%',
+    [string] $branch = '%mr.GitVersion.branch%',
+    [string] $commitId = '%mr.GitVersion.commitId%',
+    [string] $username = '%mr.GitVersion.username%',
+    [string] $password = '%mr.GitVersion.password%',
+    [string] $logFile = '%mr.GitVersion.logFile%',
+    [string] $exec = '%mr.GitVersion.exec%',
+    [string] $execArgs = '%mr.GitVersion.execArgs%',
+    [string] $proj = '%mr.GitVersion.proj%',
+    [string] $projArgs = '%mr.GitVersion.projArgs%',
+    [string] $updateAssemblyInfo = '%mr.GitVersion.updateAssemblyInfo%',
+    [string] $updateAssemblyInfoFileName = '%mr.GitVersion.updateAssemblyInfoFileName%',
+    [string] $updateGitVersion = '%mr.GitVersion.updateGitVersion%'
+)
+
+$ErrorActionPreference = "Stop"
+
+function Join-ToWorkingDirectoryIfSpecified($path) {
+    $workingDir = "%teamcity.build.workingDir%"
+    if ($workingDir -match "teamcity.build.workingDir") {
+        return $path
+    }
+    if (Test-IsSpecified $path) {
+        return Join-Path $workingDir $path
+    }
+    return $path
+}
+
+function Test-IsSpecified ($value) {
+    if ($value -ne $null -and $value -ne "" -and -not ($value -match "mr.GitVersion.")) {
+        return $true
+    }
+    return $false
+}
+
+function Append-IfSpecified($appendTo, $command, $value) {
+    if (Test-IsSpecified $value) {
+        return "$appendTo /$command '$value'"
+    }
+    return $appendTo
+}
+
+function Build-Arguments() {
+    $args = "";
+    if (Test-IsSpecified $workingDir) {
+        $workingDir = $workingDir.TrimEnd('\')
+        $args = """$workingDir"""
+    }
+    $args = Append-IfSpecified $args "url" $url
+    $args = Append-IfSpecified $args "dynamicRepoLocation" $dynamicRepoLocation
+    $args = Append-IfSpecified $args "b" $branch
+    $args = Append-IfSpecified $args "c" $commitId
+    $args = Append-IfSpecified $args "u" $username
+    $args = Append-IfSpecified $args "p" $password
+    $args = Append-IfSpecified $args "output" $output
+    $args = Append-IfSpecified $args "l" $logFile
+    if (Test-IsSpecified $exec) {
+        $args = Append-IfSpecified $args "exec" $exec
+        $args = Append-IfSpecified $args "execargs" $execargs
+    }
+    if (Test-IsSpecified $proj) {
+        $args = Append-IfSpecified $args "proj" $proj
+        $args = Append-IfSpecified $args "projargs" $projargs
+    }
+    if ($updateAssemblyInfo -eq "true") {
+        if (Test-IsSpecified $updateAssemblyInfoFileName) {
+            $args = "$args /UpdateAssemblyInfo $updateAssemblyInfoFileName"
+        } else {
+            $args = "$args /UpdateAssemblyInfo"
+        }
+    }
+    if ($output -eq "json" -and (Test-IsSpecified $outputFile)) {
+        $args = "$args > ""$outputFile"""
+    }
+    return $args
+}
+
+try {
+
+    $chocolateyDir = $null
+    if ($env:ChocolateyInstall -ne $null) {
+        $chocolateyDir = $env:ChocolateyInstall
+    } elseif (Test-Path (Join-Path $env:SYSTEMDRIVE Chocolatey)) {
+        $chocolateyDir = Join-Path $env:SYSTEMDRIVE Chocolatey
+    } elseif (Test-Path (Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey)) {
+        $chocolateyDir = Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey
+    }
+
+    if ($chocolateyDir -eq $null) {
+        Write-Host "##teamcity[progressMessage 'Chocolatey not installed; installing Chocolatey']"
+        & { iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')) }
+        $chocolateyDir = Join-Path ([Environment]::GetFolderPath("CommonApplicationData")) Chocolatey
+        if (-not (Test-Path $chocolateyDir)) {
+            throw "Error installing Chocolatey"
+        }
+    } else {
+        Write-Host "Chocolatey already installed"
+    }
+
+    $chocolateyBinDir = Join-Path $chocolateyDir "bin"
+    $gitversion = Join-Path $chocolateyBinDir "gitversion.bat"
+    if (-not (Test-Path $gitversion)) {
+        $gitversion = Join-Path $chocolateyBinDir "gitversion.exe"
+    }
+
+    $choco = Join-Path $chocolateyDir "choco.exe"
+
+    if (-not (Test-Path $gitversion)) {
+        Write-Host "##teamcity[progressMessage 'GitVersion not installed; installing GitVersion']"
+        iex "$choco install gitversion.portable -y --pre"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Error installing GitVersion"
+        }
+    } else {
+        Write-Host "GitVersion already installed"
+    }
+
+    if ($updateGitVersion -eq "true") {
+        Write-Host "##teamcity[progressMessage 'Checking for updated version of GitVersion']"
+        iex "$choco upgrade gitversion.portable -y --pre"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Error updating GitVersion"
+        }
+    } else {
+        Write-Host "GitVersion will not be updated"
+    }
+
+    $outputFile = Join-ToWorkingDirectoryIfSpecified $outputFile
+    $logFile = Join-ToWorkingDirectoryIfSpecified $logFile
+    $exec = Join-ToWorkingDirectoryIfSpecified $exec
+    $proj = Join-ToWorkingDirectoryIfSpecified $proj
+
+    $arguments = Build-Arguments
+
+    $safeArgs = $arguments.Replace("'", """")
+
+    if($password) {
+      $safeArgs = $arguments.Replace($password, "*****")
+    }
+
+    Write-Host "##teamcity[progressMessage 'Running: $gitversion $safeArgs']"
+    iex "$gitversion $arguments"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Error running GitVersion"
+    }
+}
+catch {
+    Write-Host "##teamcity[buildStatus text='$_' status='FAILURE']"
+    Write-Host "##teamcity[message text='$_' status='ERROR']"
+    exit 1
+}
+          ]]></param>
+        </parameters>
+      </runner>
+    </build-runners>
+    <requirements />
+  </settings>
+</meta-runner>


### PR DESCRIPTION
The existing MR for GitVersion will set the `FullSemVer` variable as build number in Teamcity, this variable is purely based on the repository and does not take into account the build counter kept by Teamcity.
While in some situations (as described by @RobSmyth in GitTools/GitVersion#1367) this information is considered important or even critical.

At the moment Chocolately does not seem to offer a good way to say 'I want version 4.x, included beta- or pre-releases', so I've just had to pass the --pre parameter to the `choco install` call in these runners, this will result in the next beta release being installed (5.x?) as soon as GitVersion 4.0 is released in production.