### PR TITLE
Upgrade Deploy WAR to use HTTPS URL

### DIFF
--- a/deploy-war/MRPP_DeployWar.xml
+++ b/deploy-war/MRPP_DeployWar.xml
@@ -20,13 +20,13 @@
 <target name="prepare-cargo-task">
 <delete dir="${taskDir}"/>
 <mkdir dir="${taskDir}"/>
-<get src="http://repo1.maven.org/maven2/org/codehaus/cargo/cargo-core-uberjar/1.4.2/cargo-core-uberjar-1.4.2.jar"
+<get src="https://repo1.maven.org/maven2/org/codehaus/cargo/cargo-core-uberjar/1.4.2/cargo-core-uberjar-1.4.2.jar"
      dest="${taskDir}"/>
-<get src="http://repo1.maven.org/maven2/org/codehaus/cargo/cargo-ant/1.4.2/cargo-ant-1.4.2.jar"
+<get src="https://repo1.maven.org/maven2/org/codehaus/cargo/cargo-ant/1.4.2/cargo-ant-1.4.2.jar"
      dest="${taskDir}"/>
-<get src="http://repo1.maven.org/maven2/commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar"
+<get src="https://repo1.maven.org/maven2/commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar"
      dest="${taskDir}"/>
-<get src="http://repo1.maven.org/maven2/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar"
+<get src="https://repo1.maven.org/maven2/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar"
      dest="${taskDir}"/>
 
 <taskdef resource="cargo.tasks">


### PR DESCRIPTION
The maven repo1 URL now require HTTPS to work and will throw a 501 otherwise, so this fix is required if it is to work