### PR TITLE
Ensure a stable composer release is used

### DIFF
--- a/php/MRPP_PHP_Composer.xml
+++ b/php/MRPP_PHP_Composer.xml
@@ -27,7 +27,7 @@
 </target>
 
 <target name="getComposer" depends="create-composer-dest-dir">
-  <get src="https://getcomposer.org/composer.phar" dest="${composer.dest.dir}" verbose="on" skipexisting="false"/>
+  <get src="https://getcomposer.org/composer-stable.phar" dest="${composer.dest.dir}/composer.phar" verbose="on" skipexisting="false"/>
 </target>
 
 <target name="create-composer-dest-dir">

--- a/php/MRPP_PHP_Composer_Specific.xml
+++ b/php/MRPP_PHP_Composer_Specific.xml
@@ -27,7 +27,7 @@
 </target>
 
 <target name="getComposer" depends="create-composer-dest-dir">
-  <get src="https://getcomposer.org/composer.phar" dest="${composer.dest.dir}" verbose="on" skipexisting="false"/>
+  <get src="https://getcomposer.org/composer-stable.phar" dest="${composer.dest.dir}/composer.phar" verbose="on" skipexisting="false"/>
 </target>
 
 <target name="create-composer-dest-dir">


### PR DESCRIPTION
The Composer runner is downloading the snapshot release of composer. Should it not be using the stable release?
Currently Composer is on version 1.x but 2.x is being worked on. 

Using the snapshot version means that composer will rely on unstable dependencies, i.e.  composer-plugin-api. When building a project on the current composer 1.x it will build using composer-plugin-api 1.x. When this runner is used it will use composer-plugin-api 2.x which is unstable, and will likely fail as other stable plugins are not be compatible.


This PR ensures a stable composer is downloaded.

See the Composer download page here: https://getcomposer.org/download/


Thx