### PR TITLE
Fix AddBuildTags multitags encoding

### DIFF
--- a/add-build-tags/MRPP_AddBuildTags.xml
+++ b/add-build-tags/MRPP_AddBuildTags.xml
@@ -70,7 +70,7 @@
 
                 <replaceregexp file="${tags.file}"
                             match="(\s+)"
-                            replace="&lt;/tag&gt;&lt;tag&gt;"
+                            replace="' /&gt;&lt;tag name='"
                             flags="gm"
                 />
 


### PR DESCRIPTION
Updates the encoding for multiple tags following changes made in #143.

After #143 the xml built when using multiple tags became invalid. 
This updates the mangling so multiple tags work again.